### PR TITLE
Replace deprecated Instagram insights endpoints

### DIFF
--- a/app/api/instagram/insights/route.js
+++ b/app/api/instagram/insights/route.js
@@ -124,20 +124,24 @@ export async function GET() {
         if (hasCities) {
           const citiesData = await citiesResponse.value.json();
           const cityResults = parseDemographicBreakdown(citiesData);
-          demographics.topCities = cityResults
-            .sort((a, b) => b.value - a.value)
-            .slice(0, 5)
-            .map(r => ({ city: r.dimensionValues[0], count: r.value }));
+          if (cityResults.length > 0) {
+            demographics.topCities = cityResults
+              .sort((a, b) => b.value - a.value)
+              .slice(0, 5)
+              .map(r => ({ city: r.dimensionValues[0], count: r.value }));
+          }
         }
 
         // Parse countries
         if (hasCountries) {
           const countriesData = await countriesResponse.value.json();
           const countryResults = parseDemographicBreakdown(countriesData);
-          demographics.topCountries = countryResults
-            .sort((a, b) => b.value - a.value)
-            .slice(0, 5)
-            .map(r => ({ country: r.dimensionValues[0], count: r.value }));
+          if (countryResults.length > 0) {
+            demographics.topCountries = countryResults
+              .sort((a, b) => b.value - a.value)
+              .slice(0, 5)
+              .map(r => ({ country: r.dimensionValues[0], count: r.value }));
+          }
         }
 
         // Parse age and gender
@@ -145,24 +149,31 @@ export async function GET() {
           const ageGenderData = await ageGenderResponse.value.json();
           const ageGenderResults = parseDemographicBreakdown(ageGenderData);
 
-          let male = 0, female = 0;
-          const ageGroups = {};
+          if (ageGenderResults.length > 0) {
+            let male = 0, female = 0;
+            const ageGroups = {};
 
-          ageGenderResults.forEach(result => {
-            // dimension_values contains [age_range, gender] e.g. ["25-34", "M"]
-            const [age, gender] = result.dimensionValues;
+            ageGenderResults.forEach(result => {
+              // dimension_values contains [age_range, gender] e.g. ["25-34", "M"]
+              const [age, gender] = result.dimensionValues;
 
-            if (gender === 'M') male += result.value;
-            if (gender === 'F') female += result.value;
+              if (gender === 'M') male += result.value;
+              if (gender === 'F') female += result.value;
 
-            if (!ageGroups[age]) ageGroups[age] = 0;
-            ageGroups[age] += result.value;
-          });
+              if (!ageGroups[age]) ageGroups[age] = 0;
+              ageGroups[age] += result.value;
+            });
 
-          demographics.gender = { male, female };
-          demographics.ageGroups = Object.entries(ageGroups)
-            .sort((a, b) => b[1] - a[1])
-            .map(([age, count]) => ({ age, count }));
+            demographics.gender = { male, female };
+            demographics.ageGroups = Object.entries(ageGroups)
+              .sort((a, b) => b[1] - a[1])
+              .map(([age, count]) => ({ age, count }));
+          }
+        }
+
+        // If no demographic data was actually parsed, reset to null
+        if (Object.keys(demographics).length === 0) {
+          demographics = null;
         }
       }
     } catch (err) {


### PR DESCRIPTION
## Summary
- Replace deprecated `audience_city`, `audience_country`, `audience_gender_age` with `follower_demographics` + breakdown params
- Remove deprecated `profile_views`, `website_clicks`, `online_followers` fetches (no replacements available)
- Parallelize all independent API calls with `Promise.allSettled` for faster response times
- Add `parseDemographicBreakdown()` helper for the new response format

## Test plan
- [ ] Verify GET /api/instagram/insights returns demographics data using new endpoint format
- [ ] Verify response no longer includes `profileViews`, `websiteClicks`, or `onlineFollowers`
- [ ] Verify parallel execution completes faster than sequential (check response time)
- [ ] Verify graceful degradation when individual demographic calls fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)