### PR TITLE
fix: Handle non-JSON API error responses in performance page

### DIFF
--- a/app/performance/page.js
+++ b/app/performance/page.js
@@ -3,6 +3,16 @@
 import { useState, useEffect } from 'react';
 import Link from 'next/link';
 
+// Safe JSON parser — handles non-JSON error responses from the server
+async function safeJson(res) {
+  const text = await res.text();
+  try {
+    return JSON.parse(text);
+  } catch {
+    throw new Error(text.slice(0, 200) || `Request failed with status ${res.status}`);
+  }
+}
+
 export default function PerformancePage() {
   const [posts, setPosts] = useState([]);
   const [recentPosts, setRecentPosts] = useState([]);
@@ -29,7 +39,7 @@ export default function PerformancePage() {
   const checkInstagramConnection = async () => {
     try {
       const res = await fetch('/api/instagram/account');
-      const data = await res.json();
+      const data = await safeJson(res);
       
       if (data.connected) {
         setInstagramConnected(true);
@@ -51,7 +61,7 @@ export default function PerformancePage() {
     setLoadingRecent(true);
     try {
       const res = await fetch('/api/instagram/recent?limit=25');
-      const data = await res.json();
+      const data = await safeJson(res);
       
       if (data.error) {
         console.error('Recent posts error:', data.error);
@@ -72,7 +82,7 @@ export default function PerformancePage() {
     setLoadingInsights(true);
     try {
       const res = await fetch('/api/instagram/insights');
-      const data = await res.json();
+      const data = await safeJson(res);
       
       if (data.error) {
         console.error('Account insights error:', data.error);
@@ -89,7 +99,7 @@ export default function PerformancePage() {
   const loadMetrics = async () => {
     try {
       const res = await fetch('/api/instagram/metrics');
-      const data = await res.json();
+      const data = await safeJson(res);
       
       if (data.error) {
         throw new Error(data.error);
@@ -108,7 +118,7 @@ export default function PerformancePage() {
     setRefreshing(true);
     try {
       const res = await fetch('/api/instagram/metrics', { method: 'POST' });
-      const data = await res.json();
+      const data = await safeJson(res);
       
       if (data.success) {
         await loadMetrics();
@@ -124,7 +134,7 @@ export default function PerformancePage() {
     setLoadingHashtags(true);
     try {
       const res = await fetch('/api/hashtags');
-      const data = await res.json();
+      const data = await safeJson(res);
       if (data.success) {
         setHashtagData(data);
       }
@@ -138,7 +148,7 @@ export default function PerformancePage() {
   const loadDataHealth = async () => {
     try {
       const res = await fetch('/api/instagram/health');
-      const data = await res.json();
+      const data = await safeJson(res);
       if (data.success) {
         setDataHealth(data.health);
       }
@@ -150,7 +160,7 @@ export default function PerformancePage() {
   const loadDerivedMetrics = async () => {
     try {
       const res = await fetch('/api/instagram/derived');
-      const data = await res.json();
+      const data = await safeJson(res);
       if (data.success) {
         setDerivedData(data);
       }


### PR DESCRIPTION
## Summary
- Adds a `safeJson()` helper that reads responses as text first, then attempts `JSON.parse`
- Replaces all 8 `res.json()` calls in the performance page with `safeJson(res)`
- On parse failure, throws a readable error with the actual server message instead of the cryptic "Unexpected token 'A'" error

## Context
When an API route crashes in a way that bypasses its try/catch (e.g. import errors, unhandled exceptions), Next.js returns a plain text error page ("An error occurred..."). The frontend was calling `res.json()` directly on these responses, producing an unhelpful parse error.

## Test plan
- [ ] Verify performance page loads without errors when APIs return valid JSON
- [ ] Verify a meaningful error message is shown when an API returns non-JSON (e.g. simulate by temporarily breaking an API route)

🤖 Generated with [Claude Code](https://claude.com/claude-code)