### PR TITLE
fix: deduplicate graphFetch helper across routes

### DIFF
--- a/app/api/instagram/insights/route.js
+++ b/app/api/instagram/insights/route.js
@@ -1,16 +1,5 @@
 import { getSupabaseClient } from '@/lib/supabase';
-
-const GRAPH_API_BASE = 'https://graph.facebook.com/v21.0';
-
-/**
- * Fetch helper for Graph API calls using Authorization Bearer header.
- */
-async function graphFetch(url, accessToken) {
-  const response = await fetch(url, {
-    headers: { 'Authorization': `Bearer ${accessToken}` },
-  });
-  return response.json();
-}
+import { graphFetch, GRAPH_API_BASE } from '@/lib/instagram';
 
 /**
  * Parse the follower_demographics response format.

--- a/lib/instagram.js
+++ b/lib/instagram.js
@@ -4,7 +4,7 @@
  */
 
 const INSTAGRAM_API_VERSION = 'v21.0';
-const GRAPH_API_BASE = `https://graph.facebook.com/${INSTAGRAM_API_VERSION}`;
+export const GRAPH_API_BASE = `https://graph.facebook.com/${INSTAGRAM_API_VERSION}`;
 
 /**
  * Parse a Graph API response, throwing a clear error if Meta returns HTML
@@ -28,7 +28,7 @@ async function parseGraphResponse(response) {
  * OAuth token exchange endpoints should NOT use this — they pass
  * credentials as query parameters per the OAuth spec.
  */
-async function graphFetch(url, accessToken, options = {}) {
+export async function graphFetch(url, accessToken, options = {}) {
   const response = await fetch(url, {
     ...options,
     headers: {


### PR DESCRIPTION
## Summary

- Export `graphFetch` and `GRAPH_API_BASE` from `lib/instagram.js` (previously private)
- Remove duplicate local `graphFetch` function and `GRAPH_API_BASE` constant from `app/api/instagram/insights/route.js`
- Import the shared versions instead

No logic changes — pure deduplication.

Closes #22

## Test plan

- [ ] Verify the insights endpoint (`/api/instagram/insights`) returns the same data as before
- [ ] Verify other routes using `graphFetch` internally (e.g. `getInstagramAccount`, `getRecentMedia`) still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)