### PR TITLE
feat: Store media_type on post_metrics (#24)

### DIFF
--- a/app/api/instagram/metrics/route.js
+++ b/app/api/instagram/metrics/route.js
@@ -113,6 +113,7 @@ export async function GET(request) {
         saves: nullIfMissing(insights?.saved),
         shares: nullIfMissing(insights?.shares),
         total_interactions: nullIfMissing(insights?.total_interactions),
+        media_type: detailsResult.details?.mediaType || null,
       };
 
       const engagementRate = calculateEngagementRate(
@@ -307,6 +308,7 @@ async function processMetricsInBackground(syncId, { days = 30 } = {}) {
           saves: nullIfMissing(insights?.saved),
           shares: nullIfMissing(insights?.shares),
           total_interactions: nullIfMissing(insights?.total_interactions),
+          media_type: detailsResult.details?.mediaType || null,
         };
 
         const engagementRate = calculateEngagementRate(

--- a/lib/supabase-schema.sql
+++ b/lib/supabase-schema.sql
@@ -85,6 +85,7 @@ CREATE TABLE post_metrics (
   saves INT,
   shares INT,
   total_interactions INT,
+  media_type TEXT,
   -- Calculated metrics
   engagement_rate DECIMAL(5,2),
   -- Tracking
@@ -145,3 +146,8 @@ CREATE POLICY "Allow public insert post_metrics" ON post_metrics
 -- Migration: add total_interactions to post_metrics
 -- =====================================================
 -- ALTER TABLE post_metrics ADD COLUMN IF NOT EXISTS total_interactions INT;
+
+-- =====================================================
+-- Migration: add media_type to post_metrics
+-- =====================================================
+-- ALTER TABLE post_metrics ADD COLUMN IF NOT EXISTS media_type TEXT;


### PR DESCRIPTION
## Summary
- Adds `media_type TEXT` column to `post_metrics` table schema
- Stores media type (IMAGE, VIDEO, CAROUSEL_ALBUM) during both single-post and background metrics sync
- Adds SQL migration comment for existing databases

Closes #24 | Part of #14

## Changes
- `lib/supabase-schema.sql` — column added to CREATE TABLE + migration block
- `app/api/instagram/metrics/route.js` — media_type included in both insert paths

## Test plan
- [ ] Run migration on Supabase: `ALTER TABLE post_metrics ADD COLUMN IF NOT EXISTS media_type TEXT;`
- [ ] Trigger metrics refresh and verify `media_type` populated in new records
- [ ] Verify existing records unaffected (NULL media_type)

🤖 Generated with [Claude Code](https://claude.com/claude-code)