### PR TITLE
fix: Remove deprecated impressions references (#25)

### DIFF
--- a/app/api/instagram/derived/route.js
+++ b/app/api/instagram/derived/route.js
@@ -25,7 +25,6 @@ export async function GET(request) {
         instagram_permalink,
         instagram_media_id,
         post_metrics (
-          impressions,
           reach,
           views,
           likes,
@@ -69,7 +68,6 @@ export async function GET(request) {
         publishedAt: post.published_at,
         instagramPermalink: post.instagram_permalink,
         metrics: latestMetrics ? {
-          impressions: latestMetrics.impressions,
           reach: latestMetrics.reach,
           views: latestMetrics.views,
           likes: latestMetrics.likes,

--- a/app/api/instagram/health/route.js
+++ b/app/api/instagram/health/route.js
@@ -24,14 +24,13 @@ export async function GET() {
     // Get overall metrics health (count NULLs in recent metrics)
     const { data: recentMetrics } = await supabase
       .from('post_metrics')
-      .select('impressions, reach, views, likes, comments, saves, shares')
+      .select('reach, views, likes, comments, saves, shares')
       .order('fetched_at', { ascending: false })
       .limit(50);
     
     let totalFields = 0;
     let nullFields = 0;
     const fieldNulls = {
-      impressions: 0,
       reach: 0,
       views: 0,
       likes: 0,


### PR DESCRIPTION
## Summary
- Removes `impressions` from health check tracking (was always NULL, skewing missing-data stats)
- Removes `impressions` from derived metrics SELECT and output
- Database column kept for historical data

Closes #25 | Part of #14

## Changes
- `app/api/instagram/health/route.js` — removed from SELECT and fieldNulls
- `app/api/instagram/derived/route.js` — removed from SELECT and metrics output

## Test plan
- [ ] Health endpoint no longer reports impressions as missing
- [ ] Derived metrics endpoint still returns all other fields correctly
- [ ] Performance page renders without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)