### PR TITLE
feat: Add nightly metrics sync via systemd timer (#26)

### DIFF
--- a/deploy/instagram-metrics-sync.service
+++ b/deploy/instagram-metrics-sync.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Instagram Post Logger — Nightly metrics sync
+After=network-online.target instagram-logger.service
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/curl -s -X POST http://localhost:3000/api/instagram/metrics -H "Content-Type: application/json" -d '{"days": 30}'
+TimeoutStartSec=600
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/instagram-metrics-sync.timer
+++ b/deploy/instagram-metrics-sync.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Nightly Instagram metrics sync
+
+[Timer]
+OnCalendar=*-*-* 03:00:00
+Persistent=true
+RandomizedDelaySec=300
+
+[Install]
+WantedBy=timers.target

--- a/deploy/setup-vm.sh
+++ b/deploy/setup-vm.sh
@@ -173,17 +173,17 @@ sudo systemctl start cloudflared || sudo systemctl restart cloudflared
 
 echo ""
 
-# ─── 7. Cron Job for Nightly Backfill ────────────────────────
+# ─── 7. Systemd Timer for Nightly Metrics Sync ───────────────
 
-echo "▸ Setting up nightly metrics backfill cron job..."
+echo "▸ Setting up nightly metrics sync timer..."
 
-BACKFILL_LOG="$HOME/instagram-backfill.log"
-CRON_CMD="0 2 * * * $APP_DIR/deploy/backfill-metrics.sh >> $BACKFILL_LOG 2>&1"
+sudo cp "$APP_DIR/deploy/instagram-metrics-sync.service" /etc/systemd/system/
+sudo cp "$APP_DIR/deploy/instagram-metrics-sync.timer" /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable --now instagram-metrics-sync.timer
 
-# Add cron job if not already present (grep -v || true to avoid exit on empty crontab)
-( (crontab -l 2>/dev/null || true) | grep -v "backfill-metrics" || true ; echo "$CRON_CMD") | crontab -
-
-echo "  Cron job installed: runs daily at 2:00 AM"
+echo "  Systemd timer installed: runs daily at 03:00 UTC (with up to 5min jitter)"
+echo "  Check status: systemctl status instagram-metrics-sync.timer"
 echo ""
 
 # ─── Done ─────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Add `deploy/instagram-metrics-sync.service` (systemd oneshot) that POSTs to `localhost:3000/api/instagram/metrics` with `{"days": 30}`
- Add `deploy/instagram-metrics-sync.timer` that fires daily at 03:00 UTC with up to 5 min random jitter and `Persistent=true` for catch-up after downtime
- Update `deploy/setup-vm.sh` section 7 to install the systemd timer instead of the old cron job

Closes #26, part of #14.

### Timer details

| Setting | Value | Why |
|---------|-------|-----|
| `OnCalendar` | `03:00 UTC` | Off-peak, after midnight UK |
| `RandomizedDelaySec` | `300` (5 min) | Avoid thundering herd if multiple services fire at 03:00 |
| `Persistent` | `true` | Runs on next boot if VM was off at 03:00 |
| `TimeoutStartSec` | `600` (10 min) | Meta API rate limiting makes sync slow |

### To install on the VM

```bash
# Already handled by setup-vm.sh, but for manual install:
sudo cp deploy/instagram-metrics-sync.{service,timer} /etc/systemd/system/
sudo systemctl daemon-reload
sudo systemctl enable --now instagram-metrics-sync.timer

# Verify
systemctl list-timers instagram-metrics-sync.timer
```

## Test plan

- [ ] Verify unit files pass `systemd-analyze verify` (no syntax errors)
- [ ] Deploy to VM and confirm timer is active: `systemctl list-timers`
- [ ] Trigger manually: `sudo systemctl start instagram-metrics-sync.service`
- [ ] Check journal for success: `journalctl -u instagram-metrics-sync.service`

Generated with [Claude Code](https://claude.com/claude-code)