### PR TITLE
feat: Follower growth chart and growth rate display (#29)

### DIFF
--- a/app/api/instagram/growth/route.js
+++ b/app/api/instagram/growth/route.js
@@ -1,0 +1,137 @@
+import { getSupabaseClient } from '@/lib/supabase';
+
+export async function GET(request) {
+  try {
+    const supabase = getSupabaseClient();
+    const { searchParams } = new URL(request.url);
+    const days = searchParams.get('days') || '30';
+
+    // Get the connected Instagram account
+    const { data: accounts, error: accountError } = await supabase
+      .from('instagram_accounts')
+      .select('instagram_user_id')
+      .order('connected_at', { ascending: false })
+      .limit(1);
+
+    if (accountError) {
+      throw new Error(accountError.message);
+    }
+
+    if (!accounts || accounts.length === 0) {
+      return new Response(JSON.stringify({ success: false, error: 'No Instagram account connected' }), {
+        status: 400,
+        headers: {
+          'Content-Type': 'application/json',
+          'Cache-Control': 'no-store, no-cache, must-revalidate',
+        },
+      });
+    }
+
+    const instagramUserId = accounts[0].instagram_user_id;
+
+    // Build query with timeframe filter
+    let query = supabase
+      .from('account_snapshots')
+      .select('snapshot_date, followers_count, following_count, media_count')
+      .eq('instagram_user_id', instagramUserId)
+      .order('snapshot_date', { ascending: true });
+
+    if (days !== 'all') {
+      const daysNum = parseInt(days, 10);
+      if (![7, 30, 90].includes(daysNum)) {
+        return new Response(JSON.stringify({ success: false, error: 'Invalid days parameter. Use 7, 30, 90, or all.' }), {
+          status: 400,
+          headers: {
+            'Content-Type': 'application/json',
+            'Cache-Control': 'no-store, no-cache, must-revalidate',
+          },
+        });
+      }
+      const since = new Date();
+      since.setDate(since.getDate() - daysNum);
+      query = query.gte('snapshot_date', since.toISOString().split('T')[0]);
+    }
+
+    const { data: snapshots, error: snapshotError } = await query;
+
+    if (snapshotError) {
+      throw new Error(snapshotError.message);
+    }
+
+    // Graceful handling when < 2 snapshots
+    if (!snapshots || snapshots.length < 2) {
+      return new Response(JSON.stringify({
+        success: true,
+        snapshots: snapshots || [],
+        growth: null,
+      }), {
+        headers: {
+          'Content-Type': 'application/json',
+          'Cache-Control': 'no-store, no-cache, must-revalidate',
+        },
+      });
+    }
+
+    // Calculate daily changes (diff between consecutive days)
+    const dailyChanges = [];
+    for (let i = 1; i < snapshots.length; i++) {
+      const prev = snapshots[i - 1];
+      const curr = snapshots[i];
+      if (prev.followers_count !== null && curr.followers_count !== null) {
+        dailyChanges.push({
+          date: curr.snapshot_date,
+          change: curr.followers_count - prev.followers_count,
+          followers: curr.followers_count,
+        });
+      }
+    }
+
+    // 7-day rolling average growth rate
+    const calcRollingAvg = (window) => {
+      if (dailyChanges.length < window) return null;
+      const recent = dailyChanges.slice(-window);
+      const totalChange = recent.reduce((sum, d) => sum + d.change, 0);
+      return parseFloat((totalChange / window).toFixed(1));
+    };
+
+    const daily7dAvg = calcRollingAvg(7);
+    const daily30dAvg = calcRollingAvg(30);
+
+    // Total growth over the period
+    const first = snapshots[0];
+    const last = snapshots[snapshots.length - 1];
+    const totalGrowth = (last.followers_count ?? 0) - (first.followers_count ?? 0);
+    const growthPercent = first.followers_count > 0
+      ? parseFloat(((totalGrowth / first.followers_count) * 100).toFixed(2))
+      : 0;
+
+    // Period in days
+    const periodStart = new Date(first.snapshot_date);
+    const periodEnd = new Date(last.snapshot_date);
+    const periodDays = Math.round((periodEnd - periodStart) / (1000 * 60 * 60 * 24));
+
+    return new Response(JSON.stringify({
+      success: true,
+      snapshots,
+      growth: {
+        daily7dAvg,
+        daily30dAvg,
+        totalGrowth,
+        growthPercent,
+        periodDays,
+      },
+    }), {
+      headers: {
+        'Content-Type': 'application/json',
+        'Cache-Control': 'no-store, no-cache, must-revalidate',
+      },
+    });
+
+  } catch (error) {
+    console.error('Growth data error:', error);
+    return Response.json(
+      { error: error.message },
+      { status: 500 }
+    );
+  }
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -2514,6 +2514,105 @@ textarea:focus-visible {
 }
 
 /* =====================================================
+   Follower Growth Chart
+   ===================================================== */
+
+.growth-chart-card {
+  border-left: 3px solid var(--accent);
+}
+
+.growth-timeframe-selector {
+  display: flex;
+  gap: 0.25rem;
+  background: var(--bg-input);
+  border-radius: var(--radius-sm);
+  padding: 0.2rem;
+}
+
+.growth-timeframe-btn {
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  font-size: 0.75rem;
+  font-weight: 500;
+  padding: 0.35rem 0.65rem;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: all 0.2s var(--ease-out);
+}
+
+.growth-timeframe-btn:hover:not(.active):not(:disabled) {
+  color: var(--text-secondary);
+}
+
+.growth-timeframe-btn.active {
+  background: var(--accent-soft);
+  color: var(--accent);
+}
+
+.growth-timeframe-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.growth-stats {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.growth-stat-item {
+  text-align: center;
+  padding: 0.75rem;
+  background: var(--bg-input);
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border);
+}
+
+.growth-stat-item .growth-stat-value {
+  display: block;
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: var(--text);
+  margin-bottom: 0.25rem;
+}
+
+.growth-stat-item .growth-stat-label {
+  font-size: 0.7rem;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
+.growth-chart-container {
+  width: 100%;
+  aspect-ratio: 4 / 1;
+  min-height: 150px;
+  background: var(--bg-input);
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border);
+  padding: 0.75rem;
+  overflow: hidden;
+}
+
+.growth-chart-svg {
+  width: 100%;
+  height: 100%;
+}
+
+@media (max-width: 768px) {
+  .growth-stats {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  .growth-chart-container {
+    aspect-ratio: 3 / 1;
+    min-height: 120px;
+  }
+}
+
+/* =====================================================
    Rate Summary & Component Rates
    ===================================================== */
 

--- a/app/performance/page.js
+++ b/app/performance/page.js
@@ -31,6 +31,9 @@ export default function PerformancePage() {
   const [derivedData, setDerivedData] = useState(null);
   const [refreshDays, setRefreshDays] = useState(30);
   const [refreshResult, setRefreshResult] = useState(null);
+  const [growthData, setGrowthData] = useState(null);
+  const [loadingGrowth, setLoadingGrowth] = useState(false);
+  const [growthDays, setGrowthDays] = useState(30);
 
   useEffect(() => {
     checkInstagramConnection();
@@ -49,6 +52,7 @@ export default function PerformancePage() {
         loadRecentPosts();
         loadAccountInsights();
         loadDerivedMetrics();
+        loadGrowthData();
       } else {
         setInstagramConnected(false);
         setLoading(false);
@@ -213,6 +217,174 @@ export default function PerformancePage() {
     } catch (err) {
       console.error('Failed to load derived metrics:', err);
     }
+  };
+
+  const loadGrowthData = async (days) => {
+    const d = days ?? growthDays;
+    setLoadingGrowth(true);
+    try {
+      const res = await fetch(`/api/instagram/growth?days=${d}`);
+      const data = await safeJson(res);
+      if (data.error) {
+        console.error('Growth data error:', data.error);
+      } else {
+        setGrowthData(data);
+      }
+    } catch (err) {
+      console.error('Failed to load growth data:', err);
+    } finally {
+      setLoadingGrowth(false);
+    }
+  };
+
+  const handleGrowthDaysChange = (newDays) => {
+    setGrowthDays(newDays);
+    loadGrowthData(newDays);
+  };
+
+  // Build SVG polyline for the growth chart
+  const renderGrowthChart = () => {
+    const snapshots = growthData?.snapshots || [];
+    if (snapshots.length < 2) return null;
+
+    const followers = snapshots.map(s => s.followers_count).filter(v => v !== null);
+    if (followers.length < 2) return null;
+
+    const minVal = Math.min(...followers);
+    const maxVal = Math.max(...followers);
+    const range = maxVal - minVal || 1;
+
+    const chartWidth = 800;
+    const chartHeight = 200;
+    const padTop = 20;
+    const padBottom = 30;
+    const padLeft = 10;
+    const padRight = 10;
+    const plotWidth = chartWidth - padLeft - padRight;
+    const plotHeight = chartHeight - padTop - padBottom;
+
+    // Build polyline points
+    const points = followers.map((val, i) => {
+      const x = padLeft + (i / (followers.length - 1)) * plotWidth;
+      const y = padTop + plotHeight - ((val - minVal) / range) * plotHeight;
+      return `${x},${y}`;
+    }).join(' ');
+
+    // Build area fill path
+    const firstX = padLeft;
+    const lastX = padLeft + plotWidth;
+    const areaPath = `M${firstX},${padTop + plotHeight} ` +
+      followers.map((val, i) => {
+        const x = padLeft + (i / (followers.length - 1)) * plotWidth;
+        const y = padTop + plotHeight - ((val - minVal) / range) * plotHeight;
+        return `L${x},${y}`;
+      }).join(' ') +
+      ` L${lastX},${padTop + plotHeight} Z`;
+
+    // X-axis labels (show ~5 dates evenly spaced)
+    const labelCount = Math.min(5, snapshots.length);
+    const labelIndices = Array.from({ length: labelCount }, (_, i) =>
+      Math.round((i / (labelCount - 1)) * (snapshots.length - 1))
+    );
+
+    // Y-axis: show min and max
+    const yLabels = [
+      { val: maxVal, y: padTop },
+      { val: minVal, y: padTop + plotHeight },
+    ];
+    if (range > 0) {
+      const midVal = Math.round(minVal + range / 2);
+      yLabels.splice(1, 0, { val: midVal, y: padTop + plotHeight / 2 });
+    }
+
+    return (
+      <svg
+        viewBox={`0 0 ${chartWidth} ${chartHeight}`}
+        className="growth-chart-svg"
+        preserveAspectRatio="none"
+      >
+        {/* Grid lines */}
+        {yLabels.map((label, i) => (
+          <line
+            key={i}
+            x1={padLeft}
+            y1={label.y}
+            x2={chartWidth - padRight}
+            y2={label.y}
+            stroke="rgba(255,255,255,0.06)"
+            strokeWidth="1"
+          />
+        ))}
+
+        {/* Area fill */}
+        <path
+          d={areaPath}
+          fill="url(#growthGradient)"
+          opacity="0.3"
+        />
+
+        {/* Line */}
+        <polyline
+          points={points}
+          fill="none"
+          stroke="var(--accent)"
+          strokeWidth="2.5"
+          strokeLinejoin="round"
+          strokeLinecap="round"
+        />
+
+        {/* Gradient definition */}
+        <defs>
+          <linearGradient id="growthGradient" x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0%" stopColor="var(--accent)" stopOpacity="0.4" />
+            <stop offset="100%" stopColor="var(--accent)" stopOpacity="0" />
+          </linearGradient>
+        </defs>
+
+        {/* X-axis date labels */}
+        {labelIndices.map((idx) => {
+          const x = padLeft + (idx / (snapshots.length - 1)) * plotWidth;
+          const date = new Date(snapshots[idx].snapshot_date);
+          const label = date.toLocaleDateString('en-GB', { day: 'numeric', month: 'short' });
+          return (
+            <text
+              key={idx}
+              x={x}
+              y={chartHeight - 5}
+              textAnchor="middle"
+              fill="var(--text-muted)"
+              fontSize="11"
+              fontFamily="inherit"
+            >
+              {label}
+            </text>
+          );
+        })}
+
+        {/* Y-axis labels */}
+        {yLabels.map((label, i) => (
+          <text
+            key={`y-${i}`}
+            x={chartWidth - padRight - 5}
+            y={label.y - 5}
+            textAnchor="end"
+            fill="var(--text-muted)"
+            fontSize="10"
+            fontFamily="inherit"
+          >
+            {formatNumber(label.val)}
+          </text>
+        ))}
+
+        {/* Endpoint dot */}
+        {(() => {
+          const lastIdx = followers.length - 1;
+          const cx = padLeft + (lastIdx / (followers.length - 1)) * plotWidth;
+          const cy = padTop + plotHeight - ((followers[lastIdx] - minVal) / range) * plotHeight;
+          return <circle cx={cx} cy={cy} r="4" fill="var(--accent)" />;
+        })()}
+      </svg>
+    );
   };
 
   const calculateCorrelation = (postsData) => {
@@ -475,6 +647,85 @@ export default function PerformancePage() {
                 ))}
               </div>
             </details>
+          )}
+        </div>
+      )}
+
+      {/* Follower Growth */}
+      {instagramConnected && (
+        <div className="card growth-chart-card" style={{ marginTop: '1.5rem' }}>
+          <div className="card-header">
+            <h2 className="card-title">📈 Follower Growth</h2>
+            <div className="growth-timeframe-selector">
+              {[
+                { label: '7d', value: 7 },
+                { label: '30d', value: 30 },
+                { label: '90d', value: 90 },
+                { label: 'All', value: 'all' },
+              ].map(({ label, value }) => (
+                <button
+                  key={value}
+                  className={`growth-timeframe-btn ${growthDays === value ? 'active' : ''}`}
+                  onClick={() => handleGrowthDaysChange(value)}
+                  disabled={loadingGrowth}
+                >
+                  {label}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {loadingGrowth && !growthData ? (
+            <div className="empty-state">
+              <div className="spinner" />
+              <p>Loading growth data...</p>
+            </div>
+          ) : !growthData?.snapshots || growthData.snapshots.length < 2 ? (
+            <div className="empty-state">
+              <p>No growth data yet. Daily snapshots start recording automatically.</p>
+            </div>
+          ) : (
+            <>
+              <div className="growth-stats">
+                <div className="growth-stat-item">
+                  <span className="growth-stat-value">
+                    {formatNumber(growthData.snapshots[growthData.snapshots.length - 1].followers_count)}
+                  </span>
+                  <span className="growth-stat-label">Current Followers</span>
+                </div>
+                <div className="growth-stat-item">
+                  <span className="growth-stat-value" style={{ color: growthData.growth.totalGrowth >= 0 ? 'var(--success)' : 'var(--error)' }}>
+                    {growthData.growth.totalGrowth >= 0 ? '+' : ''}{formatNumber(growthData.growth.totalGrowth)}
+                  </span>
+                  <span className="growth-stat-label">Total Change</span>
+                </div>
+                <div className="growth-stat-item">
+                  <span className="growth-stat-value">
+                    {growthData.growth.daily7dAvg !== null
+                      ? `${growthData.growth.daily7dAvg >= 0 ? '+' : ''}${growthData.growth.daily7dAvg}/day`
+                      : 'N/A'}
+                  </span>
+                  <span className="growth-stat-label">7d Avg</span>
+                </div>
+                <div className="growth-stat-item">
+                  <span className="growth-stat-value" style={{ color: growthData.growth.growthPercent >= 0 ? 'var(--success)' : 'var(--error)' }}>
+                    {growthData.growth.growthPercent >= 0 ? '+' : ''}{growthData.growth.growthPercent}%
+                  </span>
+                  <span className="growth-stat-label">Growth Rate</span>
+                </div>
+              </div>
+
+              <div className="growth-chart-container">
+                {renderGrowthChart()}
+              </div>
+
+              {growthData.growth.periodDays > 0 && (
+                <div style={{ fontSize: '0.75rem', color: 'var(--text-dim)', textAlign: 'center', marginTop: '0.5rem' }}>
+                  Showing {growthData.growth.periodDays} day{growthData.growth.periodDays !== 1 ? 's' : ''} of data
+                  {growthData.growth.daily30dAvg !== null && ` — 30d avg: ${growthData.growth.daily30dAvg >= 0 ? '+' : ''}${growthData.growth.daily30dAvg}/day`}
+                </div>
+              )}
+            </>
           )}
         </div>
       )}


### PR DESCRIPTION
## Summary
- New `GET /api/instagram/growth` endpoint — returns snapshots with calculated daily/weekly growth rates and rolling averages, with `?days=7|30|90|all` timeframe selector
- Pure SVG growth chart on the performance page with gradient fill, polyline, grid lines, and axis labels — no chart library dependencies
- Four stat cards: current followers, total change, 7-day daily average, growth rate %
- Timeframe selector (7d / 30d / 90d / All) with pill-style toggle buttons
- Graceful empty state when < 2 snapshots exist
- No-cache headers on the growth endpoint

## Test plan
- [ ] Growth endpoint returns correct data with snapshots in DB
- [ ] Timeframe selector filters data correctly
- [ ] SVG chart renders with real snapshot data
- [ ] Stat cards show accurate growth calculations
- [ ] Empty state shows when no snapshots exist
- [ ] Responsive layout works on mobile (2-column grid)

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)