### PR TITLE
feat: Weighted composite performance score per post (#31)

### DIFF
--- a/app/api/instagram/derived/route.js
+++ b/app/api/instagram/derived/route.js
@@ -1,7 +1,8 @@
 import { getSupabaseClient } from '@/lib/supabase';
-import { 
-  calculateComponentRates, 
-  calculatePercentiles, 
+import {
+  calculateComponentRates,
+  calculatePercentiles,
+  calculatePerformanceScore,
   getBaselineWindow,
   calculateSummaryMedians,
   calculatePeriodDelta,
@@ -83,10 +84,11 @@ export async function GET(request) {
     // Get baseline for percentile calculation (last 30 posts with valid rates)
     const baseline = getBaselineWindow(processedPosts, null, 30);
     
-    // Calculate percentiles for each post
+    // Calculate percentiles and performance score for each post
     const postsWithPercentiles = processedPosts.map(post => ({
       ...post,
       percentiles: post.rates ? calculatePercentiles(post.rates, baseline) : null,
+      performanceScore: post.rates ? calculatePerformanceScore(post.rates, baseline) : null,
     }));
     
     // If specific post requested, return just that one

--- a/app/globals.css
+++ b/app/globals.css
@@ -2740,6 +2740,37 @@ textarea:focus-visible {
   background: rgba(239, 68, 68, 0.15);
 }
 
+/* Performance score badges */
+.score-badge {
+  display: inline-block;
+  font-size: 0.7rem;
+  font-weight: 700;
+  padding: 0.15rem 0.5rem;
+  border-radius: 999px;
+  margin-left: 0.5rem;
+  vertical-align: middle;
+}
+
+.score-high {
+  color: #22c55e;
+  background: rgba(34, 197, 94, 0.15);
+}
+
+.score-mid {
+  color: #f59e0b;
+  background: rgba(245, 158, 11, 0.15);
+}
+
+.score-low {
+  color: #ef4444;
+  background: rgba(239, 68, 68, 0.15);
+}
+
+.score-none {
+  color: var(--text-muted);
+  background: rgba(255, 255, 255, 0.05);
+}
+
 .insufficient-data-note {
   font-size: 0.8rem;
   color: var(--text-muted);

--- a/app/performance/page.js
+++ b/app/performance/page.js
@@ -491,6 +491,17 @@ export default function PerformancePage() {
     return <span className={`percentile-badge ${badgeClass}`}>P{percentile}</span>;
   };
 
+  // Render composite performance score badge (0-100)
+  const renderPerformanceScore = (score) => {
+    if (score === null || score === undefined) {
+      return <span className="score-badge score-none" title="Performance score unavailable (need 10+ posts)">--</span>;
+    }
+    const badgeClass = score >= 70 ? 'score-high'
+      : score >= 40 ? 'score-mid'
+      : 'score-low';
+    return <span className={`score-badge ${badgeClass}`} title={`Composite performance score: ${score}/100`}>{score}</span>;
+  };
+
   if (loading) {
     return (
       <div className="container">
@@ -1034,6 +1045,7 @@ export default function PerformancePage() {
                 <div className="performance-item-header">
                   <div>
                     <span className="performance-topic">{post.topic}</span>
+                    {renderPerformanceScore(post.performanceScore)}
                     <span className="performance-edits">✏️ {post.editCount} edits</span>
                   </div>
                   {post.instagramPermalink && (

--- a/lib/derived-metrics.js
+++ b/lib/derived-metrics.js
@@ -107,6 +107,55 @@ export function calculatePercentiles(rates, baselineRates) {
   };
 }
 
+// Default weights for composite performance score
+const SCORE_WEIGHTS = {
+  engagementRate: 0.4,
+  saveRate: 0.25,
+  shareRate: 0.2,
+  commentRate: 0.15,
+};
+
+// Calculate raw weighted score from component rates
+function calculateRawScore(rates, weights = SCORE_WEIGHTS) {
+  if (!rates) return null;
+
+  const { engagementRate, saveRate, shareRate, commentRate } = rates;
+  if (engagementRate === null || engagementRate === undefined) return null;
+
+  // Use 0 for null components (they contribute nothing)
+  const er = engagementRate ?? 0;
+  const sr = saveRate ?? 0;
+  const shr = shareRate ?? 0;
+  const cr = commentRate ?? 0;
+
+  return (
+    er * weights.engagementRate +
+    sr * weights.saveRate +
+    shr * weights.shareRate +
+    cr * weights.commentRate
+  );
+}
+
+// Composite performance score (0-100) using percentile ranking of weighted rates
+export function calculatePerformanceScore(rates, baselineRates, weights = SCORE_WEIGHTS) {
+  if (!rates) return null;
+  if (!baselineRates || baselineRates.length < 10) return null;
+
+  const rawScore = calculateRawScore(rates, weights);
+  if (rawScore === null) return null;
+
+  // Calculate raw scores for the entire baseline
+  const baselineScores = baselineRates
+    .map(b => calculateRawScore(b, weights))
+    .filter(s => s !== null);
+
+  if (baselineScores.length < 10) return null;
+
+  // Percentile rank: how many baseline scores are <= this post's score
+  const countLessOrEqual = baselineScores.filter(s => s <= rawScore).length;
+  return Math.round((countLessOrEqual / baselineScores.length) * 100);
+}
+
 // Calculate median from array of values (ignoring nulls)
 export function calculateMedian(values) {
   const valid = values.filter(v => v !== null && v !== undefined);


### PR DESCRIPTION
## Summary
- New `calculatePerformanceScore()` in `lib/derived-metrics.js` — weighted sum of engagement (40%), save (25%), share (20%), comment (15%) rates, normalised to 0-100 via percentile ranking
- Score included in derived endpoint response for each post
- Color-coded score badge on performance page (green 70+, yellow 40-69, red <40)
- NULL-safe: returns null when insufficient baseline data (<10 posts)

## Test plan
- [ ] Posts with metrics show a performance score badge
- [ ] Score colors match thresholds (green/yellow/red)
- [ ] Posts without enough baseline data show gray "--"
- [ ] Score is consistent with engagement metrics

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)