### PR TITLE
feat: Content type breakdown dashboard (#32)

### DIFF
--- a/app/api/instagram/derived/route.js
+++ b/app/api/instagram/derived/route.js
@@ -6,6 +6,7 @@ import {
   getBaselineWindow,
   calculateSummaryMedians,
   calculatePeriodDelta,
+  calculateMedian,
 } from '@/lib/derived-metrics';
 
 export async function GET(request) {
@@ -33,6 +34,7 @@ export async function GET(request) {
           saves,
           shares,
           engagement_rate,
+          media_type,
           fetched_at
         )
       `)
@@ -68,6 +70,7 @@ export async function GET(request) {
         editCount: post.edit_count,
         publishedAt: post.published_at,
         instagramPermalink: post.instagram_permalink,
+        mediaType: latestMetrics?.media_type || null,
         metrics: latestMetrics ? {
           reach: latestMetrics.reach,
           views: latestMetrics.views,
@@ -106,12 +109,31 @@ export async function GET(request) {
     // Calculate delta vs previous 28 days
     const delta = calculatePeriodDelta(processedPosts, 28);
     
+    // Calculate content type breakdown
+    const typeGroups = {};
+    for (const post of processedPosts) {
+      if (!post.mediaType || !post.rates) continue;
+      if (!typeGroups[post.mediaType]) typeGroups[post.mediaType] = [];
+      typeGroups[post.mediaType].push(post);
+    }
+
+    const contentTypeBreakdown = Object.entries(typeGroups).map(([type, typePosts]) => ({
+      type,
+      count: typePosts.length,
+      medianEngagementRate: calculateMedian(typePosts.map(p => p.rates.engagementRate)),
+      medianSaveRate: calculateMedian(typePosts.map(p => p.rates.saveRate)),
+      medianShareRate: calculateMedian(typePosts.map(p => p.rates.shareRate)),
+      medianReach: calculateMedian(typePosts.filter(p => p.metrics).map(p => p.metrics.reach)),
+      insufficientData: typePosts.length < 10,
+    }));
+
     return Response.json({
       success: true,
       posts: postsWithPercentiles,
       summary,
       delta,
       baselineSize: baseline.length,
+      contentTypeBreakdown,
     });
     
   } catch (error) {

--- a/app/globals.css
+++ b/app/globals.css
@@ -2862,3 +2862,76 @@ textarea:focus-visible {
   font-size: 0.8rem;
   color: var(--text-muted);
 }
+
+/* =====================================================
+   Content Type Breakdown
+   ===================================================== */
+
+.content-type-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+}
+
+.content-type-card {
+  background: var(--bg-input);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 1rem;
+}
+
+.content-type-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.75rem;
+}
+
+.content-type-name {
+  font-weight: 600;
+  font-size: 1rem;
+  color: var(--text);
+}
+
+.content-type-count {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+}
+
+.content-type-warning {
+  font-size: 0.75rem;
+  color: var(--warning);
+  margin-bottom: 0.75rem;
+}
+
+.content-type-stats {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 0.5rem;
+}
+
+.content-type-stat {
+  text-align: center;
+  padding: 0.5rem 0.25rem;
+}
+
+.content-type-stat-value {
+  display: block;
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: var(--text);
+  margin-bottom: 0.15rem;
+}
+
+.content-type-stat-label {
+  font-size: 0.65rem;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
+@media (max-width: 768px) {
+  .content-type-grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/app/performance/page.js
+++ b/app/performance/page.js
@@ -1024,6 +1024,50 @@ export default function PerformancePage() {
         </div>
       )}
 
+      {/* Content Type Performance */}
+      {derivedData?.contentTypeBreakdown && derivedData.contentTypeBreakdown.length > 0 && (
+        <div className="card" style={{ marginTop: '1.5rem' }}>
+          <div className="card-header">
+            <h2 className="card-title">🎬 Content Type Performance</h2>
+          </div>
+          <div className="content-type-grid">
+            {derivedData.contentTypeBreakdown.map((ct) => (
+              <div key={ct.type} className="content-type-card">
+                <div className="content-type-header">
+                  <span className="content-type-name">
+                    {ct.type === 'CAROUSEL_ALBUM' ? 'Carousel' : ct.type === 'IMAGE' ? 'Image' : ct.type === 'VIDEO' ? 'Video' : ct.type}
+                  </span>
+                  <span className="content-type-count">
+                    {ct.count} post{ct.count !== 1 ? 's' : ''}
+                  </span>
+                </div>
+                {ct.insufficientData && (
+                  <div className="content-type-warning">Small sample (n={ct.count})</div>
+                )}
+                <div className="content-type-stats">
+                  <div className="content-type-stat">
+                    <span className="content-type-stat-value">{renderRate(ct.medianEngagementRate)}</span>
+                    <span className="content-type-stat-label">Engagement</span>
+                  </div>
+                  <div className="content-type-stat">
+                    <span className="content-type-stat-value">{renderRate(ct.medianSaveRate)}</span>
+                    <span className="content-type-stat-label">Save Rate</span>
+                  </div>
+                  <div className="content-type-stat">
+                    <span className="content-type-stat-value">{renderRate(ct.medianShareRate, 3)}</span>
+                    <span className="content-type-stat-label">Share Rate</span>
+                  </div>
+                  <div className="content-type-stat">
+                    <span className="content-type-stat-value">{ct.medianReach !== null ? formatNumber(ct.medianReach) : <span className="metric-na">N/A</span>}</span>
+                    <span className="content-type-stat-label">Reach</span>
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
       {/* Published Posts with Component Rates */}
       <div className="card" style={{ marginTop: '1.5rem' }}>
         <div className="card-header">


### PR DESCRIPTION
## Summary
- Added `media_type` to derived endpoint query and response
- New `contentTypeBreakdown` in derived response — groups posts by IMAGE/VIDEO/CAROUSEL with median engagement, save, share rates and reach
- Content Type Performance section on dashboard with cards per type
- Warning badge when sample size < 10 posts
- Responsive grid layout

## Test plan
- [ ] Content types show with correct post counts
- [ ] Median rates calculated correctly per type
- [ ] Warning displays for types with < 10 posts
- [ ] Responsive layout works on mobile

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)