### PR TITLE
Release training integrity and publishing safety

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,33 @@ npm run build
 npm start
 ```
 
+### Training-data integrity migration
+
+Existing installations must classify historical rows before deploying code that
+writes explicit origins:
+
+1. Back up the `posts` table.
+2. Run `lib/migrations/20260711_add_posts_origin.sql` in the Supabase SQL Editor.
+   It classifies stable `ig_` importer IDs as `instagram_import` and all other
+   existing rows as `training_pair`.
+3. Deploy application code. New logs and imports now set `origin` explicitly;
+   voice analysis excludes Instagram imports. Pre-migration rows remain readable
+   through the same stable-ID fallback.
+4. Dry-run historical edit-count recalculation with service-role credentials:
+
+   ```bash
+   npm run recalculate:edit-counts
+   ```
+
+5. Review the report and, during a maintenance window, opt into writes:
+
+   ```bash
+   npm run recalculate:edit-counts -- --apply --confirm=RECALCULATE_EDIT_COUNTS
+   ```
+
+The recalculation command never writes by default. It only considers rows marked
+`training_pair`; imported Instagram history remains untouched.
+
 ---
 
 ## Instagram Integration

--- a/app/(app)/calendar/page.js
+++ b/app/(app)/calendar/page.js
@@ -112,12 +112,16 @@ export default function CalendarPage() {
 
   async function handleCancelPost(postId) {
     try {
-      await fetch(`/api/publish/draft?id=${postId}`, { method: 'DELETE' });
-      fetchPosts(currentDate);
-      if (selectedDay) {
-        const remaining = posts.filter(p => p.id !== postId);
-        setPosts(remaining);
+      const res = await fetch('/api/publish/cancel', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ id: postId }),
+      });
+      if (!res.ok) {
+        const data = await res.json();
+        throw new Error(data.error || 'Failed to cancel post');
       }
+      fetchPosts(currentDate);
     } catch (err) {
       console.error('Failed to cancel post:', err);
     }

--- a/app/(app)/compose/page.js
+++ b/app/(app)/compose/page.js
@@ -110,9 +110,14 @@ function ComposePageInner() {
         .then((data) => {
           const posts = data.posts || data.data || [];
           const match = posts.find(
-            (p) => String(p.post_id) === fromPostId || String(p.id) === fromPostId
+            (p) => String(p.id) === fromPostId ||
+              String(p.postId) === fromPostId ||
+              String(p.post_id) === fromPostId
           );
           if (match) {
+            // Normalize legacy sourcePostId URLs before draft creation so the
+            // scheduled_posts foreign key always receives canonical posts.id.
+            sourcePostId.current = match.id;
             setCaption(match.final_version || match.finalVersion || '');
           }
         })

--- a/app/(app)/compose/page.js
+++ b/app/(app)/compose/page.js
@@ -546,6 +546,7 @@ function ComposePageInner() {
                   onClick={() => setShowHashtagPicker(true)}
                   style={toolButtonStyle}
                   title="Insert hashtags"
+                  aria-label="Insert hashtags"
                 >
                   #
                 </button>
@@ -553,6 +554,7 @@ function ComposePageInner() {
                   onClick={() => setShowTemplatePicker(true)}
                   style={toolButtonStyle}
                   title="Load template"
+                  aria-label="Load caption template"
                 >
                   <TemplateIcon />
                 </button>

--- a/app/(app)/edit/page.js
+++ b/app/(app)/edit/page.js
@@ -91,17 +91,29 @@ export default function EditPage() {
       <header className="header">
         <div className="header-main">
           <h1>Edit Post</h1>
-          <p>Paste from Claude Chat, edit to your voice, log for training</p>
+          <p>Paste an AI draft, refine it in your voice, then save what changed</p>
         </div>
       </header>
 
+      <div className="input-group editor-topic-field">
+        <label htmlFor="post-topic">Topic (optional)</label>
+        <input
+          id="post-topic"
+          type="text"
+          value={topic}
+          onChange={(e) => setTopic(e.target.value)}
+          placeholder="e.g., Selfridges Food Hall, M&S Night..."
+          disabled={isLocked}
+        />
+      </div>
+
       <div className="main-grid">
-        {/* Left Column - Original from Claude */}
+        {/* Left Column - Original AI draft */}
         <div className="card">
           <div className="card-header">
             <h2 className="card-title">
               <span className="step">1</span>
-              Original from Claude
+              AI Draft
             </h2>
             {isLocked && (
               <span className="status-badge status-locked">
@@ -110,24 +122,17 @@ export default function EditPage() {
             )}
           </div>
 
-          <div className="input-group">
-            <label>Topic (optional)</label>
-            <input
-              type="text"
-              value={topic}
-              onChange={(e) => setTopic(e.target.value)}
-              placeholder="e.g., Selfridges Food Hall, M&S Night..."
+          <div className="editor-field">
+            <label htmlFor="ai-draft">AI-generated draft</label>
+            <textarea
+              id="ai-draft"
+              value={original}
+              onChange={(e) => setOriginal(e.target.value)}
+              placeholder="Paste an AI-generated Instagram caption here..."
               disabled={isLocked}
+              style={isLocked ? { opacity: 0.6, cursor: 'not-allowed' } : {}}
             />
           </div>
-
-          <textarea
-            value={original}
-            onChange={(e) => setOriginal(e.target.value)}
-            placeholder="Paste the Instagram post from Claude Chat here..."
-            disabled={isLocked}
-            style={isLocked ? { opacity: 0.6, cursor: 'not-allowed' } : {}}
-          />
 
           {!isLocked && (
             <div className="btn-group">
@@ -147,7 +152,7 @@ export default function EditPage() {
           <div className="card-header">
             <h2 className="card-title">
               <span className="step">2</span>
-              Your Version
+              Refined Version
             </h2>
             {edited && (
               <button
@@ -160,18 +165,17 @@ export default function EditPage() {
             )}
           </div>
 
-          <div className="input-group" style={{ visibility: 'hidden', height: '72px' }}>
-            <label>Spacer</label>
-            <input type="text" disabled />
+          <div className="editor-field">
+            <label htmlFor="refined-version">Your refined caption</label>
+            <textarea
+              id="refined-version"
+              value={edited}
+              onChange={(e) => setEdited(e.target.value)}
+              placeholder={isLocked ? "Edit the caption to match your voice..." : "Start editing to lock the AI draft first..."}
+              disabled={!isLocked}
+              style={!isLocked ? { opacity: 0.4 } : {}}
+            />
           </div>
-
-          <textarea
-            value={edited}
-            onChange={(e) => setEdited(e.target.value)}
-            placeholder={isLocked ? "Edit the post here to match your voice..." : "Click 'Start Editing' first to lock the original..."}
-            disabled={!isLocked}
-            style={!isLocked ? { opacity: 0.4 } : {}}
-          />
 
           <div className="btn-group">
             <button
@@ -237,7 +241,7 @@ export default function EditPage() {
           <div className="workflow-container">
             <div className="workflow-step">
               <span className="workflow-icon">{'\uD83D\uDCAC'}</span>
-              <span className="workflow-label">Get post from<br/>Claude Chat</span>
+              <span className="workflow-label">Generate an<br/>AI draft</span>
             </div>
             <span className="workflow-arrow">{'\u2192'}</span>
             <div className="workflow-step">
@@ -252,7 +256,7 @@ export default function EditPage() {
             <span className="workflow-arrow">{'\u2192'}</span>
             <div className="workflow-step">
               <span className="workflow-icon">{'\uD83D\uDCBE'}</span>
-              <span className="workflow-label">Log for<br/>training</span>
+              <span className="workflow-label">Save changes<br/>to learn</span>
             </div>
           </div>
         </div>
@@ -260,7 +264,7 @@ export default function EditPage() {
 
       {/* Toast */}
       {toast && (
-        <div className={`toast toast-${toast.type}`}>
+        <div className={`toast toast-${toast.type}`} role={toast.type === 'error' ? 'alert' : 'status'}>
           {toast.type === 'success' ? '\u2713' : '\u2715'} {toast.message}
         </div>
       )}

--- a/app/(app)/edit/page.test.js
+++ b/app/(app)/edit/page.test.js
@@ -1,0 +1,14 @@
+import { render, screen } from '@testing-library/react';
+import EditPage from './page';
+
+describe('EditPage', () => {
+  it('uses AI-neutral wording and real form labels', () => {
+    render(<EditPage />);
+
+    expect(screen.getByLabelText('Topic (optional)')).toBeInTheDocument();
+    expect(screen.getByLabelText('AI-generated draft')).toBeInTheDocument();
+    expect(screen.getByLabelText('Your refined caption')).toBeInTheDocument();
+    expect(screen.queryByText(/Claude/i)).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Spacer')).not.toBeInTheDocument();
+  });
+});

--- a/app/(app)/error.js
+++ b/app/(app)/error.js
@@ -1,0 +1,21 @@
+'use client';
+
+import { useEffect } from 'react';
+
+export default function AppError({ error, reset }) {
+  useEffect(() => {
+    console.error('App route error:', error);
+  }, [error]);
+
+  return (
+    <div className="container route-state">
+      <div className="card route-state-card" role="alert">
+        <h1>Couldn&apos;t load this page</h1>
+        <p>Your work is still safe. Try loading this section again.</p>
+        <button className="btn btn-primary" onClick={reset}>
+          Try again
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/app/(app)/history/[id]/page.js
+++ b/app/(app)/history/[id]/page.js
@@ -28,7 +28,11 @@ export default function ViewPostPage() {
     try {
       const res = await fetch('/api/posts');
       const data = await res.json();
-      const found = (data.posts || []).find(p => String(p.id) === String(id));
+      const found = (data.posts || []).find(p =>
+        String(p.id) === String(id) ||
+        String(p.postId) === String(id) ||
+        String(p.post_id) === String(id)
+      );
       setPost(found || null);
     } catch (error) {
       console.error('Failed to load post:', error);
@@ -75,6 +79,7 @@ export default function ViewPostPage() {
           postId: post.id,
           instagramMediaId: instagramPost.id,
           instagramPermalink: instagramPost.permalink,
+          publishedAt: instagramPost.timestamp,
         }),
       });
       const data = await res.json();
@@ -84,6 +89,7 @@ export default function ViewPostPage() {
           ...post,
           instagramMediaId: instagramPost.id,
           instagramPermalink: instagramPost.permalink,
+          publishedAt: instagramPost.timestamp,
         });
         setShowLinkModal(false);
       } else {
@@ -104,7 +110,7 @@ export default function ViewPostPage() {
       const data = await res.json();
       if (data.success) {
         showToast('Post unlinked from Instagram');
-        setPost({ ...post, instagramMediaId: null, instagramPermalink: null });
+        setPost({ ...post, instagramMediaId: null, instagramPermalink: null, publishedAt: null });
       } else {
         showToast(data.error || 'Failed to unlink', 'error');
       }
@@ -146,6 +152,7 @@ export default function ViewPostPage() {
               ...post,
               instagramMediaId: accepted.instagramMediaId,
               instagramPermalink: accepted.instagramPermalink,
+              publishedAt: accepted.instagramPublishedAt || post.publishedAt,
             });
           }
           setShowLinkModal(false);

--- a/app/(app)/loading.js
+++ b/app/(app)/loading.js
@@ -1,0 +1,10 @@
+export default function AppLoading() {
+  return (
+    <div className="container route-state" role="status" aria-live="polite">
+      <div className="card route-state-card">
+        <span className="loading-spinner" aria-hidden="true" />
+        <p className="route-loading-label">Loading workspace...</p>
+      </div>
+    </div>
+  );
+}

--- a/app/(app)/queue/page.js
+++ b/app/(app)/queue/page.js
@@ -167,7 +167,15 @@ export default function QueuePage() {
 
   async function handleCancel(postId) {
     try {
-      await fetch(`/api/publish/draft?id=${postId}`, { method: 'DELETE' });
+      const res = await fetch('/api/publish/cancel', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ id: postId }),
+      });
+      if (!res.ok) {
+        const data = await res.json();
+        throw new Error(data.error || 'Failed to cancel post');
+      }
       await fetchAll();
     } catch (err) {
       console.error('Failed to cancel post:', err);

--- a/app/(app)/settings/page.js
+++ b/app/(app)/settings/page.js
@@ -10,6 +10,7 @@ export default function SettingsPage() {
   const [connecting, setConnecting] = useState(false);
   const [disconnecting, setDisconnecting] = useState(false);
   const [error, setError] = useState(null);
+  const [oauthFeedback, setOauthFeedback] = useState(null);
 
   // Import state
   const [importing, setImporting] = useState(false);
@@ -62,6 +63,19 @@ export default function SettingsPage() {
   }, []);
 
   useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const connectedUsername = params.get('instagram_connected');
+    const oauthError = params.get('instagram_error');
+
+    if (connectedUsername) {
+      setOauthFeedback({
+        type: 'success',
+        message: `Instagram account @${connectedUsername} connected successfully.`,
+      });
+    } else if (oauthError) {
+      setOauthFeedback({ type: 'error', message: oauthError });
+    }
+
     loadInstagramAccount();
     loadLibrary();
     loadBackfillStatus();
@@ -268,6 +282,17 @@ export default function SettingsPage() {
           <p>Configure your Instagram connection and app preferences</p>
         </div>
       </header>
+
+      {oauthFeedback && (
+        <div
+          className={`settings-feedback settings-feedback-${oauthFeedback.type}`}
+          role={oauthFeedback.type === 'error' ? 'alert' : 'status'}
+          aria-live="polite"
+        >
+          <strong>{oauthFeedback.type === 'error' ? 'Instagram connection failed' : 'Instagram connected'}</strong>
+          <span>{oauthFeedback.message}</span>
+        </div>
+      )}
 
       {/* Instagram Connection */}
       <div className="card" style={{ marginTop: '1.5rem' }}>
@@ -761,6 +786,7 @@ INSTAGRAM_REDIRECT_URI=${typeof window !== 'undefined' ? window.location.origin 
                       {tag.hashtag}
                       <button
                         onClick={() => handleRemoveHashtag(tag.id)}
+                        aria-label={`Remove ${tag.hashtag} from library`}
                         style={{
                           background: 'none',
                           border: 'none',
@@ -770,7 +796,6 @@ INSTAGRAM_REDIRECT_URI=${typeof window !== 'undefined' ? window.location.origin 
                           fontSize: '0.9rem',
                           lineHeight: '1',
                         }}
-                        title="Remove"
                       >
                         x
                       </button>

--- a/app/(app)/settings/page.test.js
+++ b/app/(app)/settings/page.test.js
@@ -1,0 +1,37 @@
+import { render, screen } from '@testing-library/react';
+import SettingsPage from './page';
+
+describe('SettingsPage OAuth feedback', () => {
+  beforeEach(() => {
+    window.history.replaceState({}, '', '/settings?instagram_connected=creator');
+    global.fetch = jest.fn(async (url) => ({
+      json: async () => {
+        if (String(url).includes('/api/hashtags/library')) {
+          return { success: true, hashtags: [], categories: [] };
+        }
+        if (String(url).includes('/api/instagram/account')) {
+          return { connected: false };
+        }
+        return { success: false };
+      },
+    }));
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    window.history.replaceState({}, '', '/settings');
+  });
+
+  it('keeps successful OAuth feedback visible on Settings', async () => {
+    render(<SettingsPage />);
+
+    expect(await screen.findByRole('status')).toHaveTextContent('Instagram account @creator connected successfully.');
+  });
+
+  it('keeps OAuth failures visible as an alert', async () => {
+    window.history.replaceState({}, '', '/settings?instagram_error=Permission%20denied');
+    render(<SettingsPage />);
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('Permission denied');
+  });
+});

--- a/app/api/analyse/route.js
+++ b/app/api/analyse/route.js
@@ -1,4 +1,5 @@
 import { getServerSupabaseClient } from '@/lib/supabase-server';
+import { isTrainingPair } from '@/lib/post-origin';
 
 // Common phrases that indicate marketing-speak to avoid
 const MARKETING_PHRASES = [
@@ -627,16 +628,17 @@ export async function GET() {
       throw new Error(error.message);
     }
 
-    if (!data || data.length === 0) {
+    const posts = (data || []).filter(isTrainingPair);
+
+    if (posts.length === 0) {
       return Response.json({
         totalPosts: 0,
-        message: 'No posts to analyse yet. Log some posts first!',
+        message: 'No training pairs to analyse yet. Log some posts first!',
         analysis: null,
         suggestions: []
       });
     }
 
-    const posts = data;
     const aiVersions = posts.map(p => p.ai_version);
     const finalVersions = posts.map(p => p.final_version);
     

--- a/app/api/cron/poll-new-posts/route.js
+++ b/app/api/cron/poll-new-posts/route.js
@@ -1,5 +1,6 @@
 import { getServerSupabaseClient } from '@/lib/supabase-server';
 import { getRecentMedia } from '@/lib/instagram';
+import { POST_ORIGINS } from '@/lib/post-origin';
 
 /**
  * Extract a short topic string from an Instagram caption.
@@ -75,6 +76,7 @@ export async function GET() {
       published_at: media.timestamp,
       media_type: media.media_type || null,
       media_product_type: media.media_product_type || null,
+      origin: POST_ORIGINS.INSTAGRAM_IMPORT,
     }));
 
     const { data: inserted, error: insertError } = await supabase

--- a/app/api/cron/publish-cleanup/route.js
+++ b/app/api/cron/publish-cleanup/route.js
@@ -3,6 +3,7 @@
  * Daily cleanup for the publishing pipeline.
  * 1. Fails posts stuck in 'publishing' for >24 hours
  * 2. Deletes orphaned media uploads (no scheduled_post_id, older than 24h)
+ * 3. Removes old cancelled-post media while preserving post and audit records
  *
  * Called via systemd timer alongside the nightly cron.
  */
@@ -84,7 +85,7 @@ export async function GET() {
 
     if (cancelError) throw new Error(cancelError.message);
 
-    let cancelledCleaned = 0;
+    let cancelledMediaCleaned = 0;
     if (cancelledPosts && cancelledPosts.length > 0) {
       for (const post of cancelledPosts) {
         const { data: media } = await supabase
@@ -95,16 +96,14 @@ export async function GET() {
         if (media) {
           for (const m of media) {
             try { await deleteFromStorage(m.storage_path); } catch { /* noop */ }
+            await supabase.from('media_uploads').delete().eq('id', m.id);
+            cancelledMediaCleaned++;
           }
         }
-
-        // Delete the post (cascades to media_uploads and publishing_log)
-        await supabase.from('scheduled_posts').delete().eq('id', post.id);
-        cancelledCleaned++;
       }
     }
 
-    results.cancelledPostsCleaned = cancelledCleaned;
+    results.cancelledMediaCleaned = cancelledMediaCleaned;
 
     console.log('Publish cleanup completed:', JSON.stringify(results));
     return Response.json({ success: true, results });

--- a/app/api/cron/publish/route.js
+++ b/app/api/cron/publish/route.js
@@ -9,6 +9,10 @@
 
 import { getServerSupabaseClient } from '@/lib/supabase-server';
 import { executePublish } from '@/lib/publishing';
+import {
+  CRON_CLAIMABLE_STATUSES,
+  claimPostForPublishing,
+} from '@/lib/publish-state';
 
 const MAX_POSTS_PER_RUN = 5;
 
@@ -46,18 +50,29 @@ export async function GET() {
 
     // Process each due post
     for (const post of duePosts) {
+      let claimedPost = null;
       try {
-        // Set status to publishing
-        await supabase
-          .from('scheduled_posts')
-          .update({ status: 'publishing', updated_at: new Date().toISOString() })
-          .eq('id', post.id);
+        claimedPost = await claimPostForPublishing(
+          supabase,
+          post.id,
+          CRON_CLAIMABLE_STATUSES,
+          { requireDue: true }
+        );
+
+        if (!claimedPost) {
+          results.push({
+            id: post.id,
+            status: 'skipped',
+            reason: 'Post already claimed or state changed',
+          });
+          continue;
+        }
 
         // Fetch media uploads
         const { data: media } = await supabase
           .from('media_uploads')
           .select('*')
-          .eq('scheduled_post_id', post.id)
+          .eq('scheduled_post_id', claimedPost.id)
           .order('sort_order', { ascending: true });
 
         if (!media || media.length === 0) {
@@ -68,8 +83,9 @@ export async function GET() {
               publish_error: 'No media files attached',
               updated_at: new Date().toISOString(),
             })
-            .eq('id', post.id);
-          results.push({ id: post.id, status: 'failed', error: 'No media files' });
+            .eq('id', claimedPost.id)
+            .eq('status', 'publishing');
+          results.push({ id: claimedPost.id, status: 'failed', error: 'No media files' });
           continue;
         }
 
@@ -77,15 +93,37 @@ export async function GET() {
         const result = await executePublish(
           account.access_token,
           account.instagram_user_id,
-          post,
+          claimedPost,
           media
         );
 
-        results.push({ id: post.id, status: 'published', mediaId: result.mediaId });
+        results.push({ id: claimedPost.id, status: 'published', mediaId: result.mediaId });
       } catch (err) {
         console.error(`Cron publish failed for post ${post.id}:`, err);
 
-        const newRetryCount = (post.retry_count || 0) + 1;
+        if (!claimedPost) {
+          results.push({ id: post.id, status: 'claim_failed', error: err.message });
+          continue;
+        }
+
+        if (err.publishSucceeded) {
+          await supabase
+            .from('scheduled_posts')
+            .update({
+              publish_error: err.message,
+              updated_at: new Date().toISOString(),
+            })
+            .eq('id', claimedPost.id)
+            .eq('status', 'publishing');
+          results.push({
+            id: claimedPost.id,
+            status: 'state_save_failed',
+            error: err.message,
+          });
+          continue;
+        }
+
+        const newRetryCount = (claimedPost.retry_count || 0) + 1;
         if (newRetryCount < 3) {
           // Retry in 5 minutes
           await supabase
@@ -97,8 +135,9 @@ export async function GET() {
               publish_error: err.message,
               updated_at: new Date().toISOString(),
             })
-            .eq('id', post.id);
-          results.push({ id: post.id, status: 'retry', attempt: newRetryCount, error: err.message });
+            .eq('id', claimedPost.id)
+            .eq('status', 'publishing');
+          results.push({ id: claimedPost.id, status: 'retry', attempt: newRetryCount, error: err.message });
         } else {
           // Permanent failure
           await supabase
@@ -109,8 +148,9 @@ export async function GET() {
               retry_count: newRetryCount,
               updated_at: new Date().toISOString(),
             })
-            .eq('id', post.id);
-          results.push({ id: post.id, status: 'failed', error: err.message });
+            .eq('id', claimedPost.id)
+            .eq('status', 'publishing');
+          results.push({ id: claimedPost.id, status: 'failed', error: err.message });
         }
       }
     }

--- a/app/api/cron/publish/route.test.js
+++ b/app/api/cron/publish/route.test.js
@@ -1,0 +1,96 @@
+import { GET } from './route';
+import { getServerSupabaseClient } from '@/lib/supabase-server';
+import { executePublish } from '@/lib/publishing';
+
+jest.mock('@/lib/supabase-server', () => ({
+  getServerSupabaseClient: jest.fn(),
+}));
+jest.mock('@/lib/publishing', () => ({
+  executePublish: jest.fn(),
+}));
+
+const originalResponse = global.Response;
+
+beforeAll(() => {
+  global.Response = {
+    json: (body, init = {}) => ({
+      status: init.status || 200,
+      json: async () => body,
+    }),
+  };
+});
+
+afterAll(() => {
+  global.Response = originalResponse;
+});
+
+function queryBuilder(result) {
+  const builder = {};
+  for (const method of ['select', 'eq', 'lte', 'order', 'limit']) {
+    builder[method] = jest.fn(() => builder);
+  }
+  builder.then = (resolve, reject) => Promise.resolve(result).then(resolve, reject);
+  return builder;
+}
+
+function makeClient(rpcResult) {
+  const dueQuery = queryBuilder({
+    data: [{ id: 9, status: 'scheduled', retry_count: 0 }],
+    error: null,
+  });
+  const accountQuery = queryBuilder({
+    data: [{ access_token: 'token', instagram_user_id: 'ig-user' }],
+    error: null,
+  });
+
+  return {
+    from: jest.fn(table => ({
+      scheduled_posts: dueQuery,
+      instagram_accounts: accountQuery,
+    })[table]),
+    rpc: jest.fn().mockResolvedValue(rpcResult),
+  };
+}
+
+describe('cron publishing claim handling', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('skips stale due-list entry when another worker owns claim', async () => {
+    const client = makeClient({ data: [], error: null });
+    getServerSupabaseClient.mockReturnValue(client);
+
+    const response = await GET();
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.results).toEqual([{
+      id: 9,
+      status: 'skipped',
+      reason: 'Post already claimed or state changed',
+    }]);
+    expect(client.rpc).toHaveBeenCalledWith(
+      'claim_scheduled_post_for_publishing',
+      expect.objectContaining({ p_require_due: true })
+    );
+    expect(executePublish).not.toHaveBeenCalled();
+  });
+
+  test('reports RPC errors as claim failures without publishing', async () => {
+    const client = makeClient({ data: null, error: { message: 'RPC unavailable' } });
+    getServerSupabaseClient.mockReturnValue(client);
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    const response = await GET();
+    const body = await response.json();
+
+    expect(body.results[0]).toEqual({
+      id: 9,
+      status: 'claim_failed',
+      error: 'Could not claim post for publishing: RPC unavailable',
+    });
+    expect(executePublish).not.toHaveBeenCalled();
+    errorSpy.mockRestore();
+  });
+});

--- a/app/api/instagram/callback/route.js
+++ b/app/api/instagram/callback/route.js
@@ -30,13 +30,13 @@ export async function GET(request) {
   if (error) {
     const errorDescription = searchParams.get('error_description') || 'Authorization failed';
     return NextResponse.redirect(
-      buildRedirect(request, `/?instagram_error=${encodeURIComponent(errorDescription)}`)
+      buildRedirect(request, `/settings?instagram_error=${encodeURIComponent(errorDescription)}`)
     );
   }
 
   if (!code) {
     return NextResponse.redirect(
-      buildRedirect(request, '/?instagram_error=No authorization code received')
+      buildRedirect(request, '/settings?instagram_error=No authorization code received')
     );
   }
 
@@ -48,7 +48,7 @@ export async function GET(request) {
 
   if (!storedState || !returnedState || returnedState !== storedState) {
     return NextResponse.redirect(
-      buildRedirect(request, '/?instagram_error=OAuth state mismatch — please try connecting again')
+      buildRedirect(request, '/settings?instagram_error=OAuth state mismatch — please try connecting again')
     );
   }
 
@@ -84,13 +84,13 @@ export async function GET(request) {
     }
 
     return NextResponse.redirect(
-      buildRedirect(request, `/?instagram_connected=${encodeURIComponent(account.username)}`)
+      buildRedirect(request, `/settings?instagram_connected=${encodeURIComponent(account.username)}`)
     );
 
   } catch (error) {
     console.error('Instagram OAuth error:', error);
     return NextResponse.redirect(
-      buildRedirect(request, `/?instagram_error=${encodeURIComponent(error.message)}`)
+      buildRedirect(request, `/settings?instagram_error=${encodeURIComponent(error.message)}`)
     );
   }
 }

--- a/app/api/instagram/callback/route.test.js
+++ b/app/api/instagram/callback/route.test.js
@@ -1,0 +1,67 @@
+import { cookies } from 'next/headers';
+import { exchangeCodeForToken, getInstagramAccount } from '@/lib/instagram';
+import { getServerSupabaseClient } from '@/lib/supabase-server';
+import { GET } from './route';
+
+jest.mock('next/headers', () => ({ cookies: jest.fn() }));
+jest.mock('next/server', () => ({
+  NextResponse: {
+    redirect: (url) => ({
+      headers: { get: (name) => name.toLowerCase() === 'location' ? String(url) : null },
+    }),
+  },
+}));
+jest.mock('@/lib/instagram', () => ({
+  exchangeCodeForToken: jest.fn(),
+  getInstagramAccount: jest.fn(),
+}));
+jest.mock('@/lib/supabase-server', () => ({ getServerSupabaseClient: jest.fn() }));
+
+describe('Instagram OAuth callback feedback', () => {
+  const originalRedirectUri = process.env.INSTAGRAM_REDIRECT_URI;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.INSTAGRAM_REDIRECT_URI = 'https://app.example.com/api/instagram/callback';
+  });
+
+  afterAll(() => {
+    process.env.INSTAGRAM_REDIRECT_URI = originalRedirectUri;
+  });
+
+  it('returns provider failures to Settings with durable feedback', async () => {
+    const response = await GET({
+      url: 'https://app.example.com/api/instagram/callback?error=access_denied&error_description=Permission%20denied',
+    });
+    const location = new URL(response.headers.get('location'));
+
+    expect(location.pathname).toBe('/settings');
+    expect(location.searchParams.get('instagram_error')).toBe('Permission denied');
+  });
+
+  it('returns successful connections to Settings with the username', async () => {
+    cookies.mockResolvedValue({
+      get: jest.fn(() => ({ value: 'valid-state' })),
+      delete: jest.fn(),
+    });
+    exchangeCodeForToken.mockResolvedValue({ accessToken: 'token', expiresIn: 3600 });
+    getInstagramAccount.mockResolvedValue({
+      instagramUserId: '123',
+      username: 'creator',
+      facebookPageId: '456',
+    });
+    getServerSupabaseClient.mockReturnValue({
+      from: jest.fn(() => ({
+        upsert: jest.fn().mockResolvedValue({ error: null }),
+      })),
+    });
+
+    const response = await GET({
+      url: 'https://app.example.com/api/instagram/callback?code=abc&state=valid-state',
+    });
+    const location = new URL(response.headers.get('location'));
+
+    expect(location.pathname).toBe('/settings');
+    expect(location.searchParams.get('instagram_connected')).toBe('creator');
+  });
+});

--- a/app/api/instagram/import/route.js
+++ b/app/api/instagram/import/route.js
@@ -1,5 +1,6 @@
 import { getServerSupabaseClient } from '@/lib/supabase-server';
 import { getRecentMedia, getTokenExpiryDate } from '@/lib/instagram';
+import { POST_ORIGINS } from '@/lib/post-origin';
 
 /**
  * Persist a refreshed access token to the instagram_accounts table.
@@ -97,6 +98,7 @@ async function processImportInBackground(syncId) {
         published_at: media.timestamp,
         media_type: media.media_type || null,
         media_product_type: media.media_product_type || null,
+        origin: POST_ORIGINS.INSTAGRAM_IMPORT,
       }));
 
       const { data: inserted, error: insertError } = await supabase

--- a/app/api/log/route.js
+++ b/app/api/log/route.js
@@ -1,4 +1,5 @@
 import { getServerSupabaseClient } from '@/lib/supabase-server';
+import { POST_ORIGINS } from '@/lib/post-origin';
 
 export async function POST(request) {
   try {
@@ -20,6 +21,7 @@ export async function POST(request) {
         ai_version: aiVersion,
         final_version: finalVersion,
         edit_count: editCount || 0,
+        origin: POST_ORIGINS.TRAINING_PAIR,
       })
       .select()
       .single();

--- a/app/api/log/route.js
+++ b/app/api/log/route.js
@@ -32,7 +32,9 @@ export async function POST(request) {
 
     // Format response to match expected structure
     const newPost = {
-      id: data.post_id,
+      id: data.id,
+      postId: data.post_id,
+      post_id: data.post_id,
       topic: data.topic,
       aiVersion: data.ai_version,
       finalVersion: data.final_version,

--- a/app/api/posts/link/route.js
+++ b/app/api/posts/link/route.js
@@ -1,26 +1,60 @@
 import { getServerSupabaseClient } from '@/lib/supabase-server';
+import { resolvePostIdentity } from '@/lib/post-identity';
+
+async function resolvePublishedAt(supabase, instagramMediaId, suppliedTimestamp) {
+  if (suppliedTimestamp) {
+    const parsed = new Date(suppliedTimestamp);
+    if (Number.isNaN(parsed.getTime())) {
+      throw new Error('publishedAt must be a valid timestamp');
+    }
+    return parsed.toISOString();
+  }
+
+  if (!instagramMediaId) return null;
+
+  const { data, error } = await supabase
+    .from('posts')
+    .select('published_at')
+    .eq('instagram_media_id', instagramMediaId)
+    .not('published_at', 'is', null)
+    .limit(1)
+    .maybeSingle();
+
+  if (error) throw new Error(error.message);
+  return data?.published_at || null;
+}
 
 // Link a logged post to an Instagram post
 export async function POST(request) {
   try {
-    const { postId, instagramMediaId, instagramPermalink } = await request.json();
+    const { postId, instagramMediaId, instagramPermalink, publishedAt } = await request.json();
     
     if (!postId) {
       return Response.json({ error: 'postId is required' }, { status: 400 });
     }
     
     const supabase = getServerSupabaseClient();
-    
-    // Update the post with Instagram link (use post_id which is the UUID)
+    const post = await resolvePostIdentity(supabase, postId);
+    if (!post) {
+      return Response.json({ error: 'Post not found' }, { status: 404 });
+    }
+
+    let instagramPublishedAt;
+    try {
+      instagramPublishedAt = await resolvePublishedAt(supabase, instagramMediaId, publishedAt);
+    } catch (error) {
+      return Response.json({ error: error.message }, { status: 400 });
+    }
+
     const { data, error } = await supabase
       .from('posts')
       .update({
         instagram_media_id: instagramMediaId || null,
         instagram_permalink: instagramPermalink || null,
-        published_at: instagramMediaId ? new Date().toISOString() : null,
+        published_at: instagramPublishedAt,
         updated_at: new Date().toISOString(),
       })
-      .eq('post_id', postId)
+      .eq('id', post.id)
       .select()
       .single();
     
@@ -51,7 +85,11 @@ export async function DELETE(request) {
     }
     
     const supabase = getServerSupabaseClient();
-    
+    const post = await resolvePostIdentity(supabase, postId);
+    if (!post) {
+      return Response.json({ error: 'Post not found' }, { status: 404 });
+    }
+
     const { data, error } = await supabase
       .from('posts')
       .update({
@@ -60,7 +98,7 @@ export async function DELETE(request) {
         published_at: null,
         updated_at: new Date().toISOString(),
       })
-      .eq('post_id', postId)
+      .eq('id', post.id)
       .select()
       .single();
     

--- a/app/api/posts/link/route.test.js
+++ b/app/api/posts/link/route.test.js
@@ -1,0 +1,52 @@
+/** @jest-environment node */
+
+jest.mock('@/lib/supabase-server', () => ({
+  getServerSupabaseClient: jest.fn(),
+}));
+
+const { getServerSupabaseClient } = require('@/lib/supabase-server');
+const { POST } = require('./route');
+
+describe('POST /api/posts/link publication timestamp', () => {
+  it('links by canonical ID and stores supplied Instagram timestamp', async () => {
+    const update = jest.fn((payload) => ({
+      eq: jest.fn((column, value) => ({
+        select: () => ({
+          single: async () => ({ data: { id: value, ...payload }, error: null }),
+        }),
+      })),
+    }));
+    const from = jest.fn((table) => {
+      if (table !== 'posts') throw new Error(`Unexpected table: ${table}`);
+      return {
+        select: () => ({
+          eq: () => ({
+            maybeSingle: async () => ({ data: { id: 73, post_id: '1712345000000' }, error: null }),
+          }),
+        }),
+        update,
+      };
+    });
+    getServerSupabaseClient.mockReturnValue({ from });
+
+    const request = new Request('http://localhost/api/posts/link', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        postId: 73,
+        instagramMediaId: 'ig-media-73',
+        instagramPermalink: 'https://www.instagram.com/p/example/',
+        publishedAt: '2026-07-01T12:34:56+00:00',
+      }),
+    });
+    const response = await POST(request);
+
+    expect(response.status).toBe(200);
+    expect(update).toHaveBeenCalledWith(expect.objectContaining({
+      instagram_media_id: 'ig-media-73',
+      published_at: '2026-07-01T12:34:56.000Z',
+    }));
+    const updateQuery = update.mock.results[0].value;
+    expect(updateQuery.eq).toHaveBeenCalledWith('id', 73);
+  });
+});

--- a/app/api/posts/match/route.js
+++ b/app/api/posts/match/route.js
@@ -1,6 +1,7 @@
 import { getServerSupabaseClient } from '@/lib/supabase-server';
 import { getRecentMedia } from '@/lib/instagram';
 import { findBestMatches } from '@/lib/matching';
+import { resolvePostIdentity } from '@/lib/post-identity';
 
 /**
  * GET /api/posts/match
@@ -12,6 +13,15 @@ export async function GET(request) {
     const postId = searchParams.get('postId');
 
     const supabase = getServerSupabaseClient();
+
+    let canonicalPostId = null;
+    if (postId) {
+      const post = await resolvePostIdentity(supabase, postId);
+      if (!post) {
+        return Response.json({ success: true, suggestions: [] });
+      }
+      canonicalPostId = post.id;
+    }
 
     let query = supabase
       .from('match_suggestions')
@@ -26,8 +36,8 @@ export async function GET(request) {
       .eq('status', 'pending')
       .order('confidence_score', { ascending: false });
 
-    if (postId) {
-      query = query.eq('post_id', postId);
+    if (canonicalPostId) {
+      query = query.eq('post_id', canonicalPostId);
     }
 
     const { data, error } = await query;
@@ -42,6 +52,7 @@ export async function GET(request) {
       instagramMediaId: s.instagram_media_id,
       instagramPermalink: s.instagram_permalink,
       instagramCaption: s.instagram_caption,
+      instagramPublishedAt: s.instagram_published_at || null,
       mediaType: s.media_type || null,
       confidenceScore: parseFloat(s.confidence_score),
       status: s.status,
@@ -151,18 +162,18 @@ export async function PUT(request) {
     }
 
     if (action === 'accept') {
-      // Look up the actual IG post timestamp from imported posts or via API
-      let publishedAt = null;
-      const { data: igPost } = await supabase
-        .from('posts')
-        .select('published_at')
-        .eq('instagram_media_id', suggestion.instagram_media_id)
-        .not('published_at', 'is', null)
-        .limit(1)
-        .single();
-
-      if (igPost?.published_at) {
-        publishedAt = igPost.published_at;
+      // New suggestions persist Graph timestamp. Legacy suggestions can still
+      // recover it from an already-imported post without inventing current time.
+      let publishedAt = suggestion.instagram_published_at || null;
+      if (!publishedAt) {
+        const { data: igPost } = await supabase
+          .from('posts')
+          .select('published_at')
+          .eq('instagram_media_id', suggestion.instagram_media_id)
+          .not('published_at', 'is', null)
+          .limit(1)
+          .maybeSingle();
+        publishedAt = igPost?.published_at || null;
       }
 
       // Link the post with Instagram data
@@ -171,7 +182,7 @@ export async function PUT(request) {
         .update({
           instagram_media_id: suggestion.instagram_media_id,
           instagram_permalink: suggestion.instagram_permalink,
-          published_at: publishedAt || new Date().toISOString(),
+          published_at: publishedAt,
           updated_at: new Date().toISOString(),
         })
         .eq('id', suggestion.post_id);
@@ -341,16 +352,21 @@ async function processMatchingInBackground(syncId, { mode, limit, dryRun }) {
             status: 'pending',
           };
 
-          // Try with media_type column first, fall back without it
+          // Optional columns allow zero-downtime rollout before the additive
+          // migration reaches every environment.
           let insertError;
           const { error: err1 } = await supabase
             .from('match_suggestions')
-            .upsert({ ...suggestionData, media_type: mediaType }, {
+            .upsert({
+              ...suggestionData,
+              media_type: mediaType,
+              instagram_published_at: match.igPost.timestamp || null,
+            }, {
               onConflict: 'post_id,instagram_media_id',
             });
 
-          if (err1 && err1.message?.includes('media_type')) {
-            // Column doesn't exist yet — insert without it
+          if (err1 && /media_type|instagram_published_at/.test(err1.message || '')) {
+            // Older schema: insert core suggestion fields without optional data.
             const { error: err2 } = await supabase
               .from('match_suggestions')
               .upsert(suggestionData, {

--- a/app/api/posts/match/route.test.js
+++ b/app/api/posts/match/route.test.js
@@ -1,0 +1,57 @@
+/** @jest-environment node */
+
+jest.mock('@/lib/supabase-server', () => ({
+  getServerSupabaseClient: jest.fn(),
+}));
+jest.mock('@/lib/instagram', () => ({ getRecentMedia: jest.fn() }));
+jest.mock('@/lib/matching', () => ({ findBestMatches: jest.fn() }));
+
+const { getServerSupabaseClient } = require('@/lib/supabase-server');
+const { GET } = require('./route');
+
+describe('GET /api/posts/match per-post filter', () => {
+  it('resolves legacy post ID and filters suggestions by canonical posts.id', async () => {
+    const filterByPost = jest.fn().mockResolvedValue({
+      data: [{
+        id: 5,
+        post_id: 31,
+        instagram_media_id: 'ig-media-1',
+        confidence_score: '0.910',
+        status: 'pending',
+        created_at: '2026-07-11T09:00:00.000Z',
+      }],
+      error: null,
+    });
+    const from = jest.fn((table) => {
+      if (table === 'posts') {
+        return {
+          select: () => ({
+            eq: () => ({
+              maybeSingle: async () => ({ data: { id: 31, post_id: 'legacy-31' }, error: null }),
+            }),
+          }),
+        };
+      }
+      if (table === 'match_suggestions') {
+        return {
+          select: () => ({
+            eq: () => ({
+              order: () => ({ eq: filterByPost }),
+            }),
+          }),
+        };
+      }
+      throw new Error(`Unexpected table: ${table}`);
+    });
+    getServerSupabaseClient.mockReturnValue({ from });
+
+    const response = await GET(new Request('http://localhost/api/posts/match?postId=legacy-31'));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(filterByPost).toHaveBeenCalledWith('post_id', 31);
+    expect(body.suggestions).toEqual([
+      expect.objectContaining({ postId: 31, instagramMediaId: 'ig-media-1' }),
+    ]);
+  });
+});

--- a/app/api/posts/route.js
+++ b/app/api/posts/route.js
@@ -24,7 +24,11 @@ export async function GET() {
     });
 
     const posts = sorted.map(post => ({
-      id: post.post_id,
+      // posts.id is the canonical internal identity used by API routes, UI
+      // links, and foreign keys. Keep both legacy spellings during migration.
+      id: post.id,
+      postId: post.post_id,
+      post_id: post.post_id,
       topic: post.topic,
       aiVersion: post.ai_version,
       finalVersion: post.final_version,

--- a/app/api/posts/route.test.js
+++ b/app/api/posts/route.test.js
@@ -1,0 +1,50 @@
+/** @jest-environment node */
+
+jest.mock('@/lib/supabase-server', () => ({
+  getServerSupabaseClient: jest.fn(),
+}));
+
+const { getServerSupabaseClient } = require('@/lib/supabase-server');
+const { GET } = require('./route');
+
+describe('GET /api/posts identity contract', () => {
+  it('uses posts.id for logged and imported rows while retaining legacy post_id', async () => {
+    const rows = [
+      {
+        id: 12,
+        post_id: '1712345678901',
+        topic: 'Logged',
+        ai_version: 'AI',
+        final_version: 'Final',
+        edit_count: 2,
+        created_at: '2026-07-10T10:00:00.000Z',
+        published_at: null,
+      },
+      {
+        id: 44,
+        post_id: 'ig_987654321',
+        topic: 'Imported',
+        ai_version: 'Imported caption',
+        final_version: 'Imported caption',
+        edit_count: 0,
+        created_at: '2026-07-09T10:00:00.000Z',
+        published_at: '2026-07-11T08:30:00.000Z',
+      },
+    ];
+    const limit = jest.fn().mockResolvedValue({ data: rows, error: null });
+    const order = jest.fn().mockReturnValue({ limit });
+    const select = jest.fn().mockReturnValue({ order });
+    getServerSupabaseClient.mockReturnValue({
+      from: jest.fn().mockReturnValue({ select }),
+    });
+
+    const response = await GET();
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.posts).toEqual(expect.arrayContaining([
+      expect.objectContaining({ id: 12, postId: '1712345678901', post_id: '1712345678901' }),
+      expect.objectContaining({ id: 44, postId: 'ig_987654321', post_id: 'ig_987654321' }),
+    ]));
+  });
+});

--- a/app/api/publish/cancel/route.js
+++ b/app/api/publish/cancel/route.js
@@ -1,4 +1,5 @@
 import { getServerSupabaseClient } from '@/lib/supabase-server';
+import { canCancel } from '@/lib/publish-state';
 
 export async function POST(request) {
   try {
@@ -28,23 +29,33 @@ export async function POST(request) {
       );
     }
 
-    if (post.status !== 'scheduled') {
+    if (!canCancel(post.status)) {
       return Response.json(
         { success: false, error: `Cannot cancel a post with status "${post.status}". Must be "scheduled".` },
         { status: 400 }
       );
     }
 
-    const { error: updateError } = await supabase
+    const { data: cancelled, error: updateError } = await supabase
       .from('scheduled_posts')
       .update({
         status: 'cancelled',
         updated_at: new Date().toISOString(),
       })
-      .eq('id', id);
+      .eq('id', id)
+      .eq('status', 'scheduled')
+      .select('id')
+      .maybeSingle();
 
     if (updateError) {
       throw new Error(updateError.message);
+    }
+
+    if (!cancelled) {
+      return Response.json(
+        { success: false, error: 'Post state changed before cancellation; refresh and try again' },
+        { status: 409 }
+      );
     }
 
     return Response.json({ success: true });

--- a/app/api/publish/draft/route.js
+++ b/app/api/publish/draft/route.js
@@ -1,10 +1,23 @@
 import { getServerSupabaseClient } from '@/lib/supabase-server';
 import { deleteAllPostMedia } from '@/lib/media';
+import { resolvePostIdentity } from '@/lib/post-identity';
 
 export async function POST(request) {
   try {
     const supabase = getServerSupabaseClient();
     const { id, caption, mediaType, altText, userTags, coverUrl, sourcePostId } = await request.json();
+    let canonicalSourcePostId = null;
+
+    if (sourcePostId) {
+      const sourcePost = await resolvePostIdentity(supabase, sourcePostId);
+      if (!sourcePost) {
+        return Response.json(
+          { success: false, error: 'Source post not found' },
+          { status: 400 }
+        );
+      }
+      canonicalSourcePostId = sourcePost.id;
+    }
 
     // Caption defaults to empty string in the DB, so allow it to be missing
     // mediaType defaults to 'IMAGE' if not provided
@@ -41,7 +54,7 @@ export async function POST(request) {
       if (altText !== undefined) updates.alt_text = altText || null;
       if (userTags !== undefined) updates.user_tags = userTags || null;
       if (coverUrl !== undefined) updates.cover_url = coverUrl || null;
-      if (sourcePostId !== undefined) updates.source_post_id = sourcePostId || null;
+      if (sourcePostId !== undefined) updates.source_post_id = canonicalSourcePostId;
 
       const { data, error } = await supabase
         .from('scheduled_posts')
@@ -66,7 +79,7 @@ export async function POST(request) {
         alt_text: altText || null,
         user_tags: userTags || null,
         cover_url: coverUrl || null,
-        source_post_id: sourcePostId || null,
+        source_post_id: canonicalSourcePostId,
         status: 'draft',
       })
       .select()

--- a/app/api/publish/draft/route.js
+++ b/app/api/publish/draft/route.js
@@ -1,6 +1,7 @@
 import { getServerSupabaseClient } from '@/lib/supabase-server';
 import { deleteAllPostMedia } from '@/lib/media';
 import { resolvePostIdentity } from '@/lib/post-identity';
+import { HARD_DELETABLE_STATUSES, canHardDelete } from '@/lib/publish-state';
 
 export async function POST(request) {
   try {
@@ -162,21 +163,54 @@ export async function DELETE(request) {
       );
     }
 
-    // Delete media files from storage first
-    try {
-      await deleteAllPostMedia(id);
-    } catch (storageError) {
-      // Log but don't block deletion if storage cleanup fails
-      console.warn('Storage cleanup warning:', storageError.message);
+    const { data: existing, error: fetchError } = await supabase
+      .from('scheduled_posts')
+      .select('id, status')
+      .eq('id', id)
+      .single();
+
+    if (fetchError || !existing) {
+      return Response.json(
+        { success: false, error: 'Draft not found' },
+        { status: 404 }
+      );
     }
 
-    const { error } = await supabase
+    if (!canHardDelete(existing.status)) {
+      return Response.json(
+        {
+          success: false,
+          error: `Cannot delete a post with status "${existing.status}". Only ${HARD_DELETABLE_STATUSES.join(' or ')} posts can be deleted.`,
+        },
+        { status: 400 }
+      );
+    }
+
+    const { data: deleted, error } = await supabase
       .from('scheduled_posts')
       .delete()
-      .eq('id', id);
+      .eq('id', id)
+      .in('status', HARD_DELETABLE_STATUSES)
+      .select('id')
+      .maybeSingle();
 
     if (error) {
       throw new Error(error.message);
+    }
+
+    if (!deleted) {
+      return Response.json(
+        { success: false, error: 'Post state changed before deletion; refresh and try again' },
+        { status: 409 }
+      );
+    }
+
+    // Database row is gone. Storage cleanup is best-effort and cannot affect
+    // publishing history because publishing_log uses ON DELETE SET NULL.
+    try {
+      await deleteAllPostMedia(id);
+    } catch (storageError) {
+      console.warn('Storage cleanup warning:', storageError.message);
     }
 
     return Response.json({ success: true });

--- a/app/api/publish/draft/route.test.js
+++ b/app/api/publish/draft/route.test.js
@@ -1,0 +1,47 @@
+/** @jest-environment node */
+
+jest.mock('@/lib/supabase-server', () => ({
+  getServerSupabaseClient: jest.fn(),
+}));
+jest.mock('@/lib/media', () => ({ deleteAllPostMedia: jest.fn() }));
+
+const { getServerSupabaseClient } = require('@/lib/supabase-server');
+const { POST } = require('./route');
+
+describe('POST /api/publish/draft source linkage', () => {
+  it('resolves legacy sourcePostId and stores canonical posts.id', async () => {
+    const insert = jest.fn((payload) => ({
+      select: () => ({
+        single: async () => ({ data: { id: 90, ...payload }, error: null }),
+      }),
+    }));
+    const from = jest.fn((table) => {
+      if (table === 'posts') {
+        return {
+          select: () => ({
+            eq: () => ({
+              maybeSingle: async () => ({ data: { id: 27, post_id: 'legacy-logged-post' }, error: null }),
+            }),
+          }),
+        };
+      }
+      if (table === 'scheduled_posts') return { insert };
+      throw new Error(`Unexpected table: ${table}`);
+    });
+    getServerSupabaseClient.mockReturnValue({ from });
+
+    const request = new Request('http://localhost/api/publish/draft', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ caption: 'Ready to publish', sourcePostId: 'legacy-logged-post' }),
+    });
+    const response = await POST(request);
+
+    expect(response.status).toBe(200);
+    expect(insert).toHaveBeenCalledWith(expect.objectContaining({
+      caption: 'Ready to publish',
+      source_post_id: 27,
+      status: 'draft',
+    }));
+  });
+});

--- a/app/api/publish/draft/route.test.js
+++ b/app/api/publish/draft/route.test.js
@@ -3,10 +3,28 @@
 jest.mock('@/lib/supabase-server', () => ({
   getServerSupabaseClient: jest.fn(),
 }));
-jest.mock('@/lib/media', () => ({ deleteAllPostMedia: jest.fn() }));
+jest.mock('@/lib/media', () => ({
+  deleteAllPostMedia: jest.fn(),
+}));
 
 const { getServerSupabaseClient } = require('@/lib/supabase-server');
-const { POST } = require('./route');
+const { deleteAllPostMedia } = require('@/lib/media');
+const { POST, DELETE } = require('./route');
+
+const originalResponse = global.Response;
+
+beforeAll(() => {
+  global.Response = {
+    json: (body, init = {}) => ({
+      status: init.status || 200,
+      json: async () => body,
+    }),
+  };
+});
+
+afterAll(() => {
+  global.Response = originalResponse;
+});
 
 describe('POST /api/publish/draft source linkage', () => {
   it('resolves legacy sourcePostId and stores canonical posts.id', async () => {
@@ -43,5 +61,39 @@ describe('POST /api/publish/draft source linkage', () => {
       source_post_id: 27,
       status: 'draft',
     }));
+  });
+});
+
+function scheduledPostClient() {
+  const query = {};
+  query.select = jest.fn(() => query);
+  query.eq = jest.fn(() => query);
+  query.single = jest.fn(async () => ({
+    data: { id: 7, status: 'scheduled' },
+    error: null,
+  }));
+
+  return {
+    client: { from: jest.fn(() => query) },
+    query,
+  };
+}
+
+describe('draft hard-delete state guard', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('preserves scheduled posts and media', async () => {
+    const { client, query } = scheduledPostClient();
+    getServerSupabaseClient.mockReturnValue(client);
+
+    const response = await DELETE({ url: 'http://localhost/api/publish/draft?id=7' });
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error).toMatch(/Cannot delete.*scheduled/);
+    expect(query.delete).toBeUndefined();
+    expect(deleteAllPostMedia).not.toHaveBeenCalled();
   });
 });

--- a/app/api/publish/now/route.js
+++ b/app/api/publish/now/route.js
@@ -1,5 +1,9 @@
 import { getServerSupabaseClient } from '@/lib/supabase-server';
 import { executePublish } from '@/lib/publishing';
+import {
+  PUBLISH_NOW_CLAIMABLE_STATUSES,
+  claimPostForPublishing,
+} from '@/lib/publish-state';
 
 export async function POST(request) {
   try {
@@ -29,8 +33,7 @@ export async function POST(request) {
       );
     }
 
-    const allowedStatuses = ['draft', 'scheduled', 'failed'];
-    if (!allowedStatuses.includes(post.status)) {
+    if (!PUBLISH_NOW_CLAIMABLE_STATUSES.includes(post.status)) {
       return Response.json(
         { success: false, error: `Cannot publish a post with status "${post.status}". Must be "draft", "scheduled", or "failed".` },
         { status: 400 }
@@ -54,19 +57,6 @@ export async function POST(request) {
       );
     }
 
-    // Update status to publishing
-    const { error: updateError } = await supabase
-      .from('scheduled_posts')
-      .update({
-        status: 'publishing',
-        updated_at: new Date().toISOString(),
-      })
-      .eq('id', id);
-
-    if (updateError) {
-      throw new Error(updateError.message);
-    }
-
     // Get Instagram account
     const { data: accounts, error: accountError } = await supabase
       .from('instagram_accounts')
@@ -74,12 +64,6 @@ export async function POST(request) {
       .limit(1);
 
     if (accountError || !accounts || accounts.length === 0) {
-      // Revert status since we can't publish
-      await supabase
-        .from('scheduled_posts')
-        .update({ status: post.status, updated_at: new Date().toISOString() })
-        .eq('id', id);
-
       return Response.json(
         { success: false, error: 'No Instagram account connected' },
         { status: 400 }
@@ -88,11 +72,32 @@ export async function POST(request) {
 
     const account = accounts[0];
 
+    const claimedPost = await claimPostForPublishing(
+      supabase,
+      id,
+      PUBLISH_NOW_CLAIMABLE_STATUSES
+    );
+
+    if (!claimedPost) {
+      return Response.json(
+        { success: false, error: 'Post is no longer claimable; another publisher may already be processing it' },
+        { status: 409 }
+      );
+    }
+
     // Kick off publish in the background (do NOT await)
-    const publishPromise = executePublish(account.access_token, account.instagram_user_id, post, mediaUploads, { dryRun: body.dryRun || false });
+    const publishPromise = executePublish(account.access_token, account.instagram_user_id, claimedPost, mediaUploads, { dryRun: body.dryRun || false });
     publishPromise.catch(async (err) => {
       const supabase = getServerSupabaseClient();
-      const newRetryCount = (post.retry_count || 0) + 1;
+      if (err.publishSucceeded) {
+        await supabase.from('scheduled_posts').update({
+          publish_error: err.message,
+          updated_at: new Date().toISOString(),
+        }).eq('id', claimedPost.id).eq('status', 'publishing');
+        return;
+      }
+
+      const newRetryCount = (claimedPost.retry_count || 0) + 1;
       if (newRetryCount < 3) {
         await supabase.from('scheduled_posts').update({
           status: 'scheduled',
@@ -100,18 +105,18 @@ export async function POST(request) {
           retry_count: newRetryCount,
           publish_error: err.message,
           updated_at: new Date().toISOString(),
-        }).eq('id', post.id);
+        }).eq('id', claimedPost.id).eq('status', 'publishing');
       } else {
         await supabase.from('scheduled_posts').update({
           status: 'failed',
           publish_error: err.message,
           retry_count: newRetryCount,
           updated_at: new Date().toISOString(),
-        }).eq('id', post.id);
+        }).eq('id', claimedPost.id).eq('status', 'publishing');
       }
     });
 
-    return Response.json({ success: true, status: 'publishing', id: post.id });
+    return Response.json({ success: true, status: 'publishing', id: claimedPost.id });
   } catch (error) {
     console.error('Publish now API error:', error);
     return Response.json(

--- a/app/api/publish/now/route.test.js
+++ b/app/api/publish/now/route.test.js
@@ -1,0 +1,93 @@
+import { POST } from './route';
+import { getServerSupabaseClient } from '@/lib/supabase-server';
+import { executePublish } from '@/lib/publishing';
+
+jest.mock('@/lib/supabase-server', () => ({
+  getServerSupabaseClient: jest.fn(),
+}));
+jest.mock('@/lib/publishing', () => ({
+  executePublish: jest.fn(),
+}));
+
+const originalResponse = global.Response;
+
+beforeAll(() => {
+  global.Response = {
+    json: (body, init = {}) => ({
+      status: init.status || 200,
+      json: async () => body,
+    }),
+  };
+});
+
+afterAll(() => {
+  global.Response = originalResponse;
+});
+
+function resolvedBuilder(result, terminal = 'then') {
+  const builder = {};
+  for (const method of ['select', 'eq', 'limit', 'order']) {
+    builder[method] = jest.fn(() => builder);
+  }
+  builder.single = jest.fn(async () => result);
+  if (terminal === 'then') {
+    builder.then = (resolve, reject) => Promise.resolve(result).then(resolve, reject);
+  }
+  return builder;
+}
+
+function makeClient(rpcResult) {
+  const postQuery = resolvedBuilder({
+    data: { id: 7, status: 'scheduled', retry_count: 0 },
+    error: null,
+  }, 'single');
+  const mediaQuery = resolvedBuilder({
+    data: [{ id: 1, scheduled_post_id: 7 }],
+    error: null,
+  });
+  const accountQuery = resolvedBuilder({
+    data: [{ access_token: 'token', instagram_user_id: 'ig-user' }],
+    error: null,
+  });
+
+  return {
+    from: jest.fn(table => ({
+      scheduled_posts: postQuery,
+      media_uploads: mediaQuery,
+      instagram_accounts: accountQuery,
+    })[table]),
+    rpc: jest.fn().mockResolvedValue(rpcResult),
+  };
+}
+
+describe('publish-now claim handling', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('returns conflict and does not publish when another worker wins claim', async () => {
+    const client = makeClient({ data: [], error: null });
+    getServerSupabaseClient.mockReturnValue(client);
+
+    const response = await POST({ json: async () => ({ id: 7 }) });
+    const body = await response.json();
+
+    expect(response.status).toBe(409);
+    expect(body.error).toMatch(/another publisher/i);
+    expect(executePublish).not.toHaveBeenCalled();
+  });
+
+  test('returns clear server error when claim RPC is unavailable', async () => {
+    const client = makeClient({ data: null, error: { message: 'RPC missing' } });
+    getServerSupabaseClient.mockReturnValue(client);
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    const response = await POST({ json: async () => ({ id: 7 }) });
+    const body = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(body.error).toBe('Could not claim post for publishing: RPC missing');
+    expect(executePublish).not.toHaveBeenCalled();
+    errorSpy.mockRestore();
+  });
+});

--- a/app/components/CaptionEditor.js
+++ b/app/components/CaptionEditor.js
@@ -37,6 +37,7 @@ export default function CaptionEditor({ caption, onCaptionChange, onInsertHashta
         }}
       >
         <textarea
+          aria-label="Instagram caption"
           ref={textareaRef}
           value={caption || ''}
           onChange={handleChange}
@@ -70,6 +71,7 @@ export default function CaptionEditor({ caption, onCaptionChange, onInsertHashta
         <div style={{ display: 'flex', gap: '8px' }}>
           <button
             onClick={onInsertHashtags}
+            aria-label="Insert hashtags into caption"
             style={{
               display: 'inline-flex',
               alignItems: 'center',
@@ -99,6 +101,7 @@ export default function CaptionEditor({ caption, onCaptionChange, onInsertHashta
 
           <button
             onClick={onLoadTemplate}
+            aria-label="Load caption template"
             style={{
               display: 'inline-flex',
               alignItems: 'center',
@@ -122,7 +125,7 @@ export default function CaptionEditor({ caption, onCaptionChange, onInsertHashta
               e.currentTarget.style.color = 'var(--text-secondary)';
             }}
           >
-            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <svg aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
               <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
               <polyline points="14 2 14 8 20 8" />
               <line x1="16" y1="13" x2="8" y2="13" />

--- a/app/components/CaptionEditor.test.js
+++ b/app/components/CaptionEditor.test.js
@@ -1,0 +1,19 @@
+import { render, screen } from '@testing-library/react';
+import CaptionEditor from './CaptionEditor';
+
+describe('CaptionEditor', () => {
+  it('names the caption and editor tool controls', () => {
+    render(
+      <CaptionEditor
+        caption=""
+        onCaptionChange={jest.fn()}
+        onInsertHashtags={jest.fn()}
+        onLoadTemplate={jest.fn()}
+      />
+    );
+
+    expect(screen.getByRole('textbox', { name: 'Instagram caption' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Insert hashtags into caption' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Load caption template' })).toBeInTheDocument();
+  });
+});

--- a/app/components/Sidebar.js
+++ b/app/components/Sidebar.js
@@ -7,10 +7,10 @@ import EngagementBadge from './EngagementBadge';
 
 const NAV_SECTIONS = [
   {
-    label: 'CONTENT',
+    label: 'REFINE',
     items: [
-      { name: 'Edit Post', href: '/edit', icon: '\u270F\uFE0F' },
-      { name: 'Post History', href: '/history', icon: '\uD83D\uDCDA' },
+      { name: 'Editor', href: '/edit', icon: '\u270F\uFE0F' },
+      { name: 'History', href: '/history', icon: '\uD83D\uDCDA' },
       { name: 'Gallery', href: '/gallery', icon: '\uD83D\uDDBC\uFE0F' },
     ],
   },
@@ -24,33 +24,22 @@ const NAV_SECTIONS = [
     ],
   },
   {
-    label: 'ENGAGEMENT',
+    label: 'MEASURE',
     items: [
+      { name: 'Dashboard', href: '/performance', icon: '\uD83D\uDCC8' },
+      { name: 'Post Metrics', href: '/performance/posts', icon: '\uD83D\uDCCB' },
       { name: 'Inbox', href: '/engagement', icon: '\uD83D\uDCEC', badge: true },
       { name: 'Mentions', href: '/engagement/mentions', icon: '\uD83D\uDD14' },
     ],
   },
   {
-    label: 'ANALYSIS',
+    label: 'LEARN',
     items: [
       { name: 'Voice Analysis', href: '/analysis', icon: '\uD83D\uDCCA' },
-    ],
-  },
-  {
-    label: 'PERFORMANCE',
-    items: [
-      { name: 'Dashboard', href: '/performance', icon: '\uD83D\uDCC8' },
-      { name: 'Post Metrics', href: '/performance/posts', icon: '\uD83D\uDCCB' },
       { name: 'Timing & Cadence', href: '/performance/timing', icon: '\u23F0' },
       { name: 'Content Analysis', href: '/performance/content', icon: '\uD83D\uDD0D' },
       { name: 'Hashtags', href: '/performance/hashtags', icon: '#' },
       { name: 'Audience', href: '/performance/audience', icon: '\uD83D\uDC65' },
-    ],
-  },
-  {
-    label: 'SETTINGS',
-    items: [
-      { name: 'Settings', href: '/settings', icon: '\u2699\uFE0F' },
     ],
   },
 ];
@@ -96,7 +85,9 @@ export default function Sidebar() {
       <button
         className="sidebar-mobile-toggle"
         onClick={toggleMobile}
-        aria-label="Toggle navigation"
+        aria-label={mobileOpen ? 'Close navigation' : 'Open navigation'}
+        aria-expanded={mobileOpen}
+        aria-controls="primary-navigation"
       >
         <span className={`hamburger ${mobileOpen ? 'open' : ''}`}>
           <span />
@@ -107,14 +98,18 @@ export default function Sidebar() {
 
       {/* Mobile overlay backdrop */}
       {mobileOpen && (
-        <div className="sidebar-overlay" onClick={() => setMobileOpen(false)} />
+        <button
+          className="sidebar-overlay"
+          onClick={() => setMobileOpen(false)}
+          aria-label="Close navigation"
+        />
       )}
 
-      <aside className={`sidebar ${collapsed ? 'sidebar-collapsed' : ''} ${mobileOpen ? 'sidebar-mobile-open' : ''}`}>
+      <aside id="primary-navigation" className={`sidebar ${collapsed ? 'sidebar-collapsed' : ''} ${mobileOpen ? 'sidebar-mobile-open' : ''}`}>
         {/* App title */}
         <div className="sidebar-header">
-          <Link href="/edit" className="sidebar-logo">
-            <span className="sidebar-logo-icon">{'\uD83D\uDCF8'}</span>
+          <Link href="/edit" className="sidebar-logo" aria-label="Post Logger editor">
+            <span className="sidebar-logo-icon" aria-hidden="true">{'\uD83D\uDCF8'}</span>
             {!collapsed && <span className="sidebar-logo-text">Post Logger</span>}
           </Link>
         </div>
@@ -135,7 +130,7 @@ export default function Sidebar() {
                       className={`sidebar-link ${isActive(item.href) ? 'sidebar-link-active' : ''}`}
                       title={collapsed ? item.name : undefined}
                     >
-                      <span className="sidebar-link-icon">{item.icon}</span>
+                      <span className="sidebar-link-icon" aria-hidden="true">{item.icon}</span>
                       {!collapsed && (
                         <span className="sidebar-link-text">{item.name}</span>
                       )}
@@ -151,8 +146,23 @@ export default function Sidebar() {
           ))}
         </nav>
 
+        <Link
+          href="/settings"
+          className={`sidebar-link sidebar-utility-link ${isActive('/settings') ? 'sidebar-link-active' : ''}`}
+          aria-label={collapsed ? 'Settings' : undefined}
+          title={collapsed ? 'Settings' : undefined}
+        >
+          <span className="sidebar-link-icon" aria-hidden="true">{'\u2699\uFE0F'}</span>
+          {!collapsed && <span className="sidebar-link-text">Settings</span>}
+        </Link>
+
         {/* Collapse toggle */}
-        <button className="sidebar-collapse-btn" onClick={toggleCollapsed}>
+        <button
+          className="sidebar-collapse-btn"
+          onClick={toggleCollapsed}
+          aria-label={collapsed ? 'Expand navigation' : 'Collapse navigation'}
+          aria-expanded={!collapsed}
+        >
           <span className={`sidebar-collapse-icon ${collapsed ? 'sidebar-collapse-icon-flipped' : ''}`}>
             {'\u00AB'}
           </span>

--- a/app/components/Sidebar.test.js
+++ b/app/components/Sidebar.test.js
@@ -1,0 +1,31 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import Sidebar from './Sidebar';
+
+jest.mock('next/navigation', () => ({ usePathname: () => '/edit' }));
+jest.mock('./EngagementBadge', () => function MockEngagementBadge() {
+  return <span>3</span>;
+});
+
+describe('Sidebar', () => {
+  beforeEach(() => localStorage.clear());
+
+  it('organises every route around the four-stage workflow', () => {
+    render(<Sidebar />);
+
+    expect(screen.getByText('REFINE')).toBeInTheDocument();
+    expect(screen.getByText('PUBLISH')).toBeInTheDocument();
+    expect(screen.getByText('MEASURE')).toBeInTheDocument();
+    expect(screen.getByText('LEARN')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Settings' })).toHaveAttribute('href', '/settings');
+  });
+
+  it('gives shell icon controls state-aware accessible names', () => {
+    render(<Sidebar />);
+
+    const mobileToggle = screen.getByRole('button', { name: 'Open navigation' });
+    fireEvent.click(mobileToggle);
+
+    expect(screen.getAllByRole('button', { name: 'Close navigation' })).toHaveLength(2);
+    expect(screen.getByRole('button', { name: 'Collapse navigation' })).toBeInTheDocument();
+  });
+});

--- a/app/globals.css
+++ b/app/globals.css
@@ -23,8 +23,8 @@
   /* Text */
   --text: #fafafa;
   --text-secondary: #b4b4b4;
-  --text-muted: #6b6b6b;
-  --text-dim: #444;
+  --text-muted: #9a9aa3;
+  --text-dim: #777780;
   
   /* Instagram gradient colors */
   --ig-pink: #e1306c;
@@ -340,6 +340,18 @@ body::before {
 .input-group input:disabled {
   opacity: 0.5;
   cursor: not-allowed;
+}
+
+.editor-topic-field {
+  max-width: 680px;
+}
+
+.editor-field label {
+  display: block;
+  margin-bottom: 0.5rem;
+  color: var(--text-secondary);
+  font-size: 0.85rem;
+  font-weight: 600;
 }
 
 /* Textarea */
@@ -1589,6 +1601,31 @@ textarea:focus-visible {
   color: var(--error);
   border-radius: var(--radius-sm);
   border-left: 3px solid var(--error);
+}
+
+.settings-feedback {
+  display: grid;
+  gap: 0.2rem;
+  margin: 0 0 1.5rem;
+  padding: 0.9rem 1rem;
+  border: 1px solid;
+  border-radius: var(--radius-md);
+}
+
+.settings-feedback-success {
+  background: var(--success-soft);
+  border-color: rgba(0, 210, 106, 0.4);
+  color: var(--success);
+}
+
+.settings-feedback-error {
+  background: var(--error-soft);
+  border-color: rgba(255, 71, 87, 0.4);
+  color: var(--error);
+}
+
+.settings-feedback span {
+  color: var(--text-secondary);
 }
 
 /* Performance Page Styles */
@@ -3112,6 +3149,11 @@ textarea:focus-visible {
   scrollbar-color: var(--bg-elevated) transparent;
 }
 
+.sidebar-utility-link {
+  flex-shrink: 0;
+  margin-top: 0.5rem;
+}
+
 .sidebar-nav::-webkit-scrollbar {
   width: 4px;
 }
@@ -3314,6 +3356,10 @@ textarea:focus-visible {
   background: rgba(0, 0, 0, 0.6);
   z-index: 90;
   backdrop-filter: blur(2px);
+  width: 100%;
+  border: 0;
+  padding: 0;
+  cursor: pointer;
 }
 
 @media (max-width: 768px) {
@@ -3354,5 +3400,51 @@ textarea:focus-visible {
   .main-content .container {
     padding-left: 1rem;
     padding-right: 1rem;
+  }
+}
+
+/* Shared route states */
+.route-state {
+  min-height: 50vh;
+  display: grid;
+  place-items: center;
+}
+
+.route-state-card {
+  width: min(100%, 520px);
+  text-align: center;
+}
+
+.route-state-card h1 {
+  margin-bottom: 0.5rem;
+}
+
+.route-state-card p {
+  margin-bottom: 1.25rem;
+  color: var(--text-muted);
+}
+
+.route-loading-label {
+  margin-top: 1rem;
+  color: var(--text-muted);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    scroll-behavior: auto !important;
+    transition-duration: 0.01ms !important;
+  }
+
+  .workflow-step:hover,
+  .correlation-card:hover {
+    transform: none;
   }
 }

--- a/docs/mi/MI-2026-07-11-canonical-post-identity.md
+++ b/docs/mi/MI-2026-07-11-canonical-post-identity.md
@@ -1,0 +1,89 @@
+# MI-2026-07-11: Canonical post identity
+
+## Trigger / symptom
+
+`/api/posts` exposed `posts.post_id` as `id`, while metrics, matching, and publishing foreign keys reference `posts.id`. History, Compose, draft creation, and manual linking therefore passed incompatible identifiers between flows. Manual linking and suggestion acceptance could also fabricate publication time from current server time.
+
+## Scope inspected
+
+- Post logging/listing and history detail UI
+- Compose-to-draft linkage
+- Manual and suggested Instagram linking
+- Automatic matching and publishing completion
+- Core and publishing schemas
+
+## Commands run
+
+- `rg --files -g 'AGENTS.md'`
+- `rg -n "post_id|sourcePostId|source_post_id|published_at|matched|match" app lib`
+- Focused `sed` inspection of affected routes, UI, publishing code, and schemas
+- `npm ci`
+- `npm test -- --runInBand app/api/posts/route.test.js app/api/publish/draft/route.test.js app/api/posts/match/route.test.js app/api/posts/link/route.test.js`
+- `npm test -- --runInBand`
+- `npm run build`
+- `git diff --check`
+
+## Files inspected
+
+- `app/api/posts/route.js`
+- `app/api/log/route.js`
+- `app/(app)/history/[id]/page.js`
+- `app/(app)/compose/page.js`
+- `app/api/publish/draft/route.js`
+- `app/api/posts/link/route.js`
+- `app/api/posts/match/route.js`
+- `lib/publishing.js`
+- `lib/supabase-schema.sql`
+- `lib/supabase-schema-publishing.sql`
+
+## Findings
+
+- `posts.id` is already canonical database identity and all internal foreign keys use it.
+- `/api/posts` and `/api/log` incorrectly replaced canonical identity with legacy `post_id`.
+- `scheduled_posts.source_post_id` already targets `posts.id`, so Compose could submit an incompatible text ID.
+- Manual link/unlink queried `posts.post_id`, unlike match resolution and publishing.
+- Recent-media payload already includes Graph `timestamp`, but manual link UI discarded it.
+- Publish pipeline fetched Graph media timestamp, but discarded it and wrote local current time.
+- Match suggestions did not persist Instagram timestamp; acceptance fell back to local current time.
+
+## Direct answers / conclusions
+
+Canonical API/UI identity must be `posts.id`. `posts.post_id` remains exposed and accepted as a legacy/public identifier. Incoming identifiers resolve canonical-first, then legacy, preventing numeric legacy IDs from breaking saved links.
+
+## Proposed surgical fix
+
+- Expose canonical `id` plus legacy `postId` and `post_id`.
+- Add shared canonical-first identity resolver.
+- Normalize legacy history/Compose links before draft persistence.
+- Filter per-post suggestions by resolved canonical ID.
+- Use canonical ID for manual link/unlink.
+- Carry Graph timestamps through manual linking, suggestions, and publish completion.
+- Add nullable, idempotent schema migration; do not rewrite existing IDs.
+
+## Files changed
+
+- `lib/post-identity.js`: canonical-first, legacy-fallback resolver
+- `app/api/posts/route.js`, `app/api/log/route.js`: canonical response ID plus legacy aliases
+- `app/(app)/history/[id]/page.js`, `app/(app)/compose/page.js`: compatible detail/source lookup and timestamp forwarding
+- `app/api/publish/draft/route.js`: canonical source foreign-key normalization
+- `app/api/posts/link/route.js`: canonical manual link/unlink and actual timestamp storage
+- `app/api/posts/match/route.js`: canonical per-post filtering and suggestion timestamp propagation
+- `lib/publishing.js`: Graph timestamp propagation into scheduled and source posts
+- `lib/supabase-schema.sql`, `lib/supabase-schema-publishing.sql`: baseline schema updates
+- `lib/migrations/2026-07-11-canonical-post-linkage.sql`: additive production migration
+- Four route test files covering required identity/linkage cases
+- `docs/mi/README.md` and this MI record
+
+## Validation status
+
+- Targeted tests: passed, 4 suites / 4 tests.
+- Full tests: passed, 5 suites / 8 tests.
+- Production build: passed, 66 routes generated.
+- `git diff --check`: passed.
+- Build emitted existing workspace-root and middleware-deprecation warnings; neither blocked compilation.
+
+## Current status / next steps
+
+Implementation complete. Apply `lib/migrations/2026-07-11-canonical-post-linkage.sql` before or with deployment. Migration is additive and idempotent; it does not rewrite `posts.id` or `posts.post_id`. Code tolerates pre-migration match-suggestion inserts, but Graph timestamps on new suggestions require the new column.
+
+Workstream 1 has no committed diff at the shared base during this closeout. No runtime dependency was found. Likely merge-conflict surfaces are `/api/log`, `/api/posts`, or shared post DTO expectations. Preserve this contract during integration: `id = posts.id`; `postId` and `post_id = posts.post_id`.

--- a/docs/mi/MI-2026-07-11-oauth-feedback-ux-shell.md
+++ b/docs/mi/MI-2026-07-11-oauth-feedback-ux-shell.md
@@ -1,0 +1,87 @@
+# MI-2026-07-11: OAuth feedback and UX shell
+
+## Trigger / symptom
+
+Instagram OAuth success and failure returned to the home route, separate from the Settings connection UI. Navigation used six product taxonomies, editor wording was Claude-specific, the editor used a hidden disabled input for spacing, and several icon controls lacked accessible names.
+
+## Scope inspected
+
+- Instagram OAuth callback redirects only; no token, identity, analysis, or publishing-state changes
+- App shell navigation and route boundaries
+- Primary refine editor and caption editor controls
+- Settings callback feedback
+- Shared CSS contrast and motion behavior
+
+## Commands run
+
+```bash
+rg --files -g 'AGENTS.md' -g '!node_modules' -g '!tuckinandtalk/**'
+git status --short --branch
+npm ci
+npm test -- --runInBand
+npm run build
+npm start -- --hostname 127.0.0.1 --port 3104
+git diff --check
+```
+
+## Files inspected
+
+- `app/api/instagram/callback/route.js`
+- `app/(app)/settings/page.js`
+- `app/(app)/edit/page.js`
+- `app/(app)/compose/page.js`
+- `app/(app)/layout.js`
+- `app/components/Sidebar.js`
+- `app/components/CaptionEditor.js`
+- `app/globals.css`
+- Jest configuration and existing layout test
+
+## Findings
+
+- Callback query feedback landed on `/`, while connection status and retry controls live on `/settings`.
+- Existing query parameters already provided a durable, refresh-preserved feedback channel; Settings did not render them.
+- All routes fit a four-stage model: Refine, Publish, Measure, Learn. Settings is a shell utility.
+- Primary editor fields lacked explicit textarea labels and used an invisible form group to align columns.
+- Sidebar collapse and mobile overlay controls, compose tool icons, and hashtag removal icons needed accessible names.
+- `--text-muted` and `--text-dim` were too dark on primary card surfaces.
+- No shared `(app)` loading or error route boundary existed.
+
+## Direct answers / conclusions
+
+- Preserve OAuth outcome in URL query parameters and return directly to Settings.
+- Keep every route; reorganize only sidebar labels and grouping.
+- Use AI-neutral copy without changing persisted `aiVersion` data contracts.
+- Use native labels and layout structure instead of hidden form controls.
+
+## Proposed surgical fix
+
+1. Redirect every OAuth callback outcome to `/settings` with existing encoded feedback parameters.
+2. Render persistent success/error feedback from the Settings URL.
+3. Collapse sidebar taxonomy into Refine, Publish, Measure, Learn; keep Settings as utility link.
+4. Add editor labels, accessible icon-control names, improved contrast, reduced-motion overrides, and shared route states.
+5. Add focused regression tests.
+
+## Files changed
+
+- OAuth: `app/api/instagram/callback/route.js` and test
+- Settings: `app/(app)/settings/page.js` and test
+- Shell: `app/components/Sidebar.js` and test
+- Editors: `app/(app)/edit/page.js`, `app/components/CaptionEditor.js`, `app/(app)/compose/page.js`, and tests
+- Route states: `app/(app)/loading.js`, `app/(app)/error.js`
+- Styles: `app/globals.css`
+- MI: this file and `docs/mi/README.md`
+
+## Validation status
+
+- Initial test run could not start because dependencies were absent.
+- After `npm ci`, first regression run exposed two test-harness issues; both tests were corrected without production-code changes.
+- Final Jest suite: passed.
+- Next.js production build: passed; existing workspace-root and middleware deprecation warnings remain.
+- Production server: started successfully.
+- Browser screenshot: not captured because both available browser surfaces blocked localhost with `ERR_BLOCKED_BY_CLIENT`.
+- Live Meta OAuth: not run because external credentials/account authorization were unavailable.
+- `npm ci` reported five dependency audit findings (one low, two moderate, two high); dependencies were not changed in this workstream.
+
+## Current status / next steps
+
+Implementation complete and locally validated. External OAuth round-trip and visual screenshot remain integration-environment checks.

--- a/docs/mi/MI-2026-07-11-publishing-state-safety.md
+++ b/docs/mi/MI-2026-07-11-publishing-state-safety.md
@@ -1,0 +1,84 @@
+# MI-2026-07-11: Publishing state safety
+
+## Trigger / symptom
+
+Queue and Calendar cancelled scheduled posts through hard delete. Publish-now and cron used separate status reads and writes, allowing concurrent workers to publish one post twice.
+
+## Scope inspected
+
+Publishing API routes, publishing orchestration, scheduled cleanup, Queue/Calendar callers, publishing schema, and test setup. `tuckinandtalk/` excluded.
+
+## Commands run
+
+```bash
+rg --files -g '!tuckinandtalk/**' -g '!node_modules/**'
+rg -n "api/publish/(draft|cancel)|DELETE|delete|cancel|publish" app lib
+sed -n ... app/api/publish/now/route.js app/api/cron/publish/route.js
+sed -n ... app/api/publish/draft/route.js app/api/publish/cancel/route.js
+sed -n ... lib/publishing.js lib/supabase-schema-publishing.sql
+```
+
+## Files inspected
+
+- `app/(app)/queue/page.js`
+- `app/(app)/calendar/page.js`
+- `app/api/publish/{now,cancel,draft}/route.js`
+- `app/api/cron/{publish,publish-cleanup}/route.js`
+- `lib/publishing.js`
+- `lib/supabase-schema-publishing.sql`
+
+## Findings
+
+- Queue and Calendar called draft DELETE for scheduled-post cancellation.
+- Draft DELETE did not validate current status and deleted storage before database state.
+- Cleanup deleted cancelled records after seven days and cascaded publishing logs.
+- Publish-now and cron selected eligible posts, then updated status without a conditional atomic claim.
+- A DB finalization failure after successful Instagram publication entered normal retry handling, risking duplicate publication.
+
+## Direct answers / conclusions
+
+Cancellation must be a retained state transition. Hard delete is limited to draft/failed rows. Publishing logs must survive parent deletion. Both entry points need one database-owned claim operation. Failures after Meta publication must never auto-retry.
+
+## Proposed surgical fix
+
+- Route Queue/Calendar cancellation through `/api/publish/cancel`.
+- Add conditional cancel/delete predicates and conflict responses.
+- Preserve cancelled rows during cleanup; delete only their old media.
+- Change publishing-log FK to `ON DELETE SET NULL`.
+- Add `claim_scheduled_post_for_publishing` SQL RPC using one conditional `UPDATE ... RETURNING`.
+- Use claim result in publish-now/cron and distinguish lost claim, RPC failure, ordinary publish failure, and state-save failure.
+- Add state-matrix, concurrent-claim, claim-failure, and route guard tests.
+
+## Files changed
+
+- Queue and Calendar cancellation callers now use the cancel endpoint.
+- Cancel and hard-delete routes apply conditional state predicates and return conflicts on races.
+- Publish-now and cron use the atomic claim helper/RPC and expose lost/error claim outcomes.
+- Publishing finalization prevents automatic retry after successful Meta publication.
+- Cleanup retains cancelled posts and logs while removing old media.
+- Initial schema plus standalone deployment migration define RPC permissions and audit FK retention.
+- Tests cover state matrices, competing claims, due-claim parameter, route conflict/error outcomes, and cron stale-list behavior.
+
+## Validation status
+
+Passed:
+
+```bash
+npm test -- --runInBand lib/publish-state.test.js app/api/publish/now/route.test.js app/api/publish/draft/route.test.js app/api/cron/publish/route.test.js
+# 4 suites, 22 tests passed
+
+npm test -- --runInBand
+# 5 suites, 26 tests passed
+
+npm run build
+# Next.js production build compiled, type-checked, and generated 66 static pages
+
+git diff --check
+# clean
+```
+
+Build emitted existing workspace-root and middleware-deprecation warnings. No build failure.
+
+## Current status / next steps
+
+Implementation and validation complete. Apply `lib/supabase-migration-publishing-state-safety.sql` before deploying application code, then commit locally. No push or merge.

--- a/docs/mi/MI-2026-07-11-release-training-integrity-integration.md
+++ b/docs/mi/MI-2026-07-11-release-training-integrity-integration.md
@@ -1,0 +1,77 @@
+# MI-2026-07-11 Release training-integrity integration
+
+## Trigger / symptom
+
+Four independently developed release commits needed integration onto current `origin/main` without losing overlapping training-data, post-identity, publishing-state, or OAuth/UX behavior.
+
+## Scope inspected
+
+- Release base: `origin/main` at `4fc39ef`
+- Training-data integrity: `0a5bbf9`
+- Canonical post identity: `c8e8b08`
+- Publishing-state safety: `b500c52`
+- OAuth feedback and UX shell: `453fb8f`
+- Expected overlap areas: log API, compose UI, draft publishing API/tests, publishing helpers/schema, and DevOps MI index
+
+## Commands run
+
+```text
+git fetch --prune origin main
+git switch -c codex/release-training-integrity origin/main
+git cherry-pick 0a5bbf9
+git cherry-pick c8e8b08
+git cherry-pick b500c52
+git cherry-pick 453fb8f
+npm ci
+npm test -- --runInBand
+npm run build
+git diff --check
+```
+
+Release validation commands and results are recorded below after completion.
+
+## Files inspected
+
+- `app/api/log/route.js`
+- `app/(app)/compose/page.js`
+- `app/api/publish/draft/route.js`
+- `app/api/publish/draft/route.test.js`
+- `lib/publishing.js`
+- `lib/supabase-schema.sql`
+- `lib/supabase-schema-publishing.sql`
+- `docs/mi/README.md`
+- All four source commit file lists and conflict stages
+
+## Findings
+
+- `app/api/log/route.js`, compose UI, and `lib/publishing.js` merged automatically while retaining changes from both touching workstreams.
+- Canonical post linkage and publishing-state safety both changed draft publishing behavior. Integrated route resolves `sourcePostId` to canonical `posts.id` and also limits hard deletion to safe statuses with a compare-and-delete state guard.
+- Draft route tests were combined so canonical linkage and hard-delete preservation remain covered.
+- Publishing schema retains canonical `source_post_id` migration notes/index plus atomic claim function and `publishing_log` retention constraint.
+- Each source commit created `docs/mi/README.md` independently. Index was manually consolidated without dropping entries.
+- Root worktree and `tuckinandtalk/` changes were not modified.
+
+## Direct answers / conclusions
+
+All four requested changes can coexist. Conflict resolution required unioning behavior, not choosing one workstream over another.
+
+## Proposed surgical fix
+
+Cherry-pick requested commits in supplied order, manually combine only conflicting behavior/index content, then verify clean install, full Jest suite, production build, and whitespace integrity.
+
+## Files changed
+
+- Four requested commit file sets
+- `docs/mi/MI-2026-07-11-release-training-integrity-integration.md`
+- `docs/mi/README.md`
+
+## Validation status
+
+- `npm ci`: passed; 409 packages installed
+- `npm test -- --runInBand`: passed; 15 suites, 59 tests
+- `npm run build`: passed; optimized production build and 66 static pages generated
+- `git diff --check`: passed after final integration record update
+
+## Current status / next steps
+
+Integration and full local validation complete. Commit MI integration record, push branch, open and merge one PR, apply available database migrations, deploy through VM protocol, verify service/application health, and review edit-count dry-run before any confirmed mutation.

--- a/docs/mi/MI-2026-07-11-training-data-integrity.md
+++ b/docs/mi/MI-2026-07-11-training-data-integrity.md
@@ -1,0 +1,90 @@
+# MI-2026-07-11 Training-data integrity
+
+## Trigger / symptom
+
+Multiline captions were diffed as one line, identical captions reported one edit,
+and imported Instagram history was included in voice/training analysis.
+
+## Scope inspected
+
+- Diff, edit-count, and similarity helpers
+- Log, Instagram import, polling, and analysis routes
+- Posts schema and historical migration path
+- Existing Jest/build setup
+
+## Commands run
+
+```bash
+rg --files
+rg -n "computeDiff|countEdits|from('posts')|edit_count" app lib
+npm test -- --runInBand
+npm ci
+npm test -- --runInBand
+npm run build
+node scripts/recalculate-edit-counts.cjs --apply
+git diff --check
+```
+
+## Files inspected
+
+- `lib/diff.js`
+- `lib/supabase-schema.sql`
+- `app/api/log/route.js`
+- `app/api/instagram/import/route.js`
+- `app/api/cron/poll-new-posts/route.js`
+- `app/api/analyse/route.js`
+- `package.json`
+
+## Findings
+
+- Diff used `/\\n/` and similarity used `/\\s+/`, matching literal backslash
+  sequences instead of newlines/whitespace.
+- `countEdits` forced a minimum of one and used `ceil(changes / 2)`, which
+  undercounted unpaired additions/removals.
+- Importers stored identical AI/final captions without a record-origin marker.
+- Analysis selected every posts row, so imported history polluted training data.
+- Existing importer IDs consistently use the `ig_` prefix; linked logged rows
+  cannot safely be identified using `instagram_media_id` alone.
+
+## Direct answers / conclusions
+
+- Identical text must report zero edits.
+- CRLF/CR/LF differences are equivalent. Blank and whitespace-only lines remain
+  meaningful caption content.
+- Explicit `origin` values are `training_pair` and `instagram_import`.
+- Legacy null/missing origins remain compatible: `ig_` rows are imports; other
+  rows are training pairs.
+
+## Proposed surgical fix
+
+- Use normalized line endings and LCS line alignment.
+- Count edits as `max(additions, removals)`, pairing replacements one-to-one.
+- Mark every writer explicitly and filter analysis through shared origin logic.
+- Add idempotent schema migration plus opt-in historical recalculation command.
+
+## Files changed
+
+- Diff implementation and unit tests
+- Shared post-origin helper and tests
+- Log/import/poll/analyse routes
+- Base schema and origin migration
+- Dry-run-first edit-count recalculation script
+- README rollout instructions and package script
+- MI record/index
+
+## Validation status
+
+- Initial test attempt: blocked because dependencies were absent (`jest: command not found`).
+- `npm ci`: passed; 409 locked packages installed. npm reported five dependency
+  audit findings (one low, two moderate, two high); no automatic upgrade applied.
+- `npm test -- --runInBand`: passed, 3 suites and 25 tests.
+- `npm run build`: passed. Existing Next.js warnings remain for inferred workspace
+  root and deprecated middleware convention.
+- `node scripts/recalculate-edit-counts.cjs --apply`: correctly refused writes
+  without the required confirmation token.
+- `git diff --check`: passed.
+
+## Current status / next steps
+
+Run origin migration before application deployment. Dry-run edit-count report,
+review it, then explicitly apply recalculation during a maintenance window.

--- a/docs/mi/README.md
+++ b/docs/mi/README.md
@@ -1,3 +1,4 @@
 # Management Investigation Index
 
 - [MI-2026-07-11 Training-data integrity](MI-2026-07-11-training-data-integrity.md)
+- [MI-2026-07-11-canonical-post-identity](MI-2026-07-11-canonical-post-identity.md)

--- a/docs/mi/README.md
+++ b/docs/mi/README.md
@@ -1,5 +1,6 @@
-# Management Investigation Index
+# DevOps MI Index
 
 - [MI-2026-07-11 Training-data integrity](MI-2026-07-11-training-data-integrity.md)
 - [MI-2026-07-11-canonical-post-identity](MI-2026-07-11-canonical-post-identity.md)
 - [MI-2026-07-11-publishing-state-safety](MI-2026-07-11-publishing-state-safety.md) — publishing transitions, record retention, and duplicate-publish prevention
+- [MI-2026-07-11 OAuth feedback and UX shell](MI-2026-07-11-oauth-feedback-ux-shell.md)

--- a/docs/mi/README.md
+++ b/docs/mi/README.md
@@ -4,3 +4,4 @@
 - [MI-2026-07-11-canonical-post-identity](MI-2026-07-11-canonical-post-identity.md)
 - [MI-2026-07-11-publishing-state-safety](MI-2026-07-11-publishing-state-safety.md) — publishing transitions, record retention, and duplicate-publish prevention
 - [MI-2026-07-11 OAuth feedback and UX shell](MI-2026-07-11-oauth-feedback-ux-shell.md)
+- [MI-2026-07-11 Release training-integrity integration](MI-2026-07-11-release-training-integrity-integration.md)

--- a/docs/mi/README.md
+++ b/docs/mi/README.md
@@ -2,3 +2,4 @@
 
 - [MI-2026-07-11 Training-data integrity](MI-2026-07-11-training-data-integrity.md)
 - [MI-2026-07-11-canonical-post-identity](MI-2026-07-11-canonical-post-identity.md)
+- [MI-2026-07-11-publishing-state-safety](MI-2026-07-11-publishing-state-safety.md) — publishing transitions, record retention, and duplicate-publish prevention

--- a/docs/mi/README.md
+++ b/docs/mi/README.md
@@ -1,0 +1,3 @@
+# Management Investigation Index
+
+- [MI-2026-07-11 Training-data integrity](MI-2026-07-11-training-data-integrity.md)

--- a/lib/diff.js
+++ b/lib/diff.js
@@ -1,70 +1,78 @@
-// Simple diff implementation for comparing AI vs Final versions
+// Line-based diff for comparing AI and final versions.
+function splitLines(text) {
+  const normalized = String(text ?? '').replace(/\r\n?/g, '\n');
+  return normalized === '' ? [] : normalized.split('\n');
+}
+
 export function computeDiff(oldText, newText) {
-  const oldLines = oldText.trim().split('\\n');
-  const newLines = newText.trim().split('\\n');
-  
+  const oldLines = splitLines(oldText);
+  const newLines = splitLines(newText);
+
+  // Build a longest-common-subsequence table. This keeps inserted/deleted
+  // lines aligned and preserves meaningful blank or whitespace-only lines.
+  const lcs = Array.from(
+    { length: oldLines.length + 1 },
+    () => new Array(newLines.length + 1).fill(0)
+  );
+
+  for (let oldIndex = oldLines.length - 1; oldIndex >= 0; oldIndex--) {
+    for (let newIndex = newLines.length - 1; newIndex >= 0; newIndex--) {
+      lcs[oldIndex][newIndex] = oldLines[oldIndex] === newLines[newIndex]
+        ? lcs[oldIndex + 1][newIndex + 1] + 1
+        : Math.max(lcs[oldIndex + 1][newIndex], lcs[oldIndex][newIndex + 1]);
+    }
+  }
+
   const changes = [];
   let oldIndex = 0;
   let newIndex = 0;
-  
-  // Simple line-by-line comparison
-  while (oldIndex < oldLines.length || newIndex < newLines.length) {
-    if (oldIndex >= oldLines.length) {
-      // Remaining lines are additions
-      changes.push({ type: 'added', content: newLines[newIndex] });
-      newIndex++;
-    } else if (newIndex >= newLines.length) {
-      // Remaining lines are removals
-      changes.push({ type: 'removed', content: oldLines[oldIndex] });
-      oldIndex++;
-    } else if (oldLines[oldIndex] === newLines[newIndex]) {
-      // Lines match
+
+  while (oldIndex < oldLines.length && newIndex < newLines.length) {
+    if (oldLines[oldIndex] === newLines[newIndex]) {
       changes.push({ type: 'unchanged', content: oldLines[oldIndex] });
       oldIndex++;
       newIndex++;
+    } else if (lcs[oldIndex + 1][newIndex] >= lcs[oldIndex][newIndex + 1]) {
+      changes.push({ type: 'removed', content: oldLines[oldIndex] });
+      oldIndex++;
     } else {
-      // Lines differ - check if it's a modification or add/remove
-      const oldLineInNew = newLines.indexOf(oldLines[oldIndex], newIndex);
-      const newLineInOld = oldLines.indexOf(newLines[newIndex], oldIndex);
-      
-      if (oldLineInNew === -1 && newLineInOld === -1) {
-        // Line was modified
-        changes.push({ type: 'removed', content: oldLines[oldIndex] });
-        changes.push({ type: 'added', content: newLines[newIndex] });
-        oldIndex++;
-        newIndex++;
-      } else if (oldLineInNew === -1 || (newLineInOld !== -1 && newLineInOld < oldLineInNew)) {
-        // Old line was removed
-        changes.push({ type: 'removed', content: oldLines[oldIndex] });
-        oldIndex++;
-      } else {
-        // New line was added
-        changes.push({ type: 'added', content: newLines[newIndex] });
-        newIndex++;
-      }
+      changes.push({ type: 'added', content: newLines[newIndex] });
+      newIndex++;
     }
   }
-  
+
+  while (oldIndex < oldLines.length) {
+    changes.push({ type: 'removed', content: oldLines[oldIndex++] });
+  }
+
+  while (newIndex < newLines.length) {
+    changes.push({ type: 'added', content: newLines[newIndex++] });
+  }
+
   return changes;
 }
 
 export function countEdits(oldText, newText) {
   const diff = computeDiff(oldText, newText);
-  const edits = diff.filter(d => d.type !== 'unchanged').length;
-  return Math.max(1, Math.ceil(edits / 2)); // Pair add/remove as single edit
+  const additions = diff.filter(change => change.type === 'added').length;
+  const removals = diff.filter(change => change.type === 'removed').length;
+
+  // A replacement is one removal paired with one addition. Unpaired lines
+  // remain individual edits.
+  return Math.max(additions, removals);
 }
 
 export function calculateSimilarity(a, b) {
   if (!a || !b) return 0;
-  
-  const aWords = a.toLowerCase().split(/\\s+/);
-  const bWords = b.toLowerCase().split(/\\s+/);
-  
+
+  const aWords = a.toLowerCase().split(/\s+/).filter(Boolean);
+  const bWords = b.toLowerCase().split(/\s+/).filter(Boolean);
+
   const aSet = new Set(aWords);
   const bSet = new Set(bWords);
-  
+
   const intersection = [...aSet].filter(x => bSet.has(x)).length;
   const union = new Set([...aWords, ...bWords]).size;
-  
+
   return union === 0 ? 1 : intersection / union;
 }

--- a/lib/diff.test.js
+++ b/lib/diff.test.js
@@ -1,0 +1,96 @@
+import { calculateSimilarity, computeDiff, countEdits } from './diff';
+
+const { countEdits: countHistoricalEdits } = require('../scripts/recalculate-edit-counts.cjs');
+
+describe('computeDiff', () => {
+  it('returns unchanged lines for identical multiline text', () => {
+    expect(computeDiff('first\nsecond', 'first\nsecond')).toEqual([
+      { type: 'unchanged', content: 'first' },
+      { type: 'unchanged', content: 'second' },
+    ]);
+  });
+
+  it('aligns inserted lines without replacing following unchanged lines', () => {
+    expect(computeDiff('first\nthird', 'first\nsecond\nthird')).toEqual([
+      { type: 'unchanged', content: 'first' },
+      { type: 'added', content: 'second' },
+      { type: 'unchanged', content: 'third' },
+    ]);
+  });
+
+  it('normalizes CRLF and CR line endings', () => {
+    expect(computeDiff('first\r\nsecond\rthird', 'first\nsecond\nthird'))
+      .toEqual([
+        { type: 'unchanged', content: 'first' },
+        { type: 'unchanged', content: 'second' },
+        { type: 'unchanged', content: 'third' },
+      ]);
+  });
+
+  it('preserves blank and whitespace-only lines', () => {
+    expect(computeDiff('first\n\nthird', 'first\n  \nthird')).toEqual([
+      { type: 'unchanged', content: 'first' },
+      { type: 'removed', content: '' },
+      { type: 'added', content: '  ' },
+      { type: 'unchanged', content: 'third' },
+    ]);
+  });
+
+  it('treats leading and trailing whitespace as content', () => {
+    expect(computeDiff(' caption ', 'caption')).toEqual([
+      { type: 'removed', content: ' caption ' },
+      { type: 'added', content: 'caption' },
+    ]);
+  });
+
+  it('handles empty input without phantom lines', () => {
+    expect(computeDiff('', '')).toEqual([]);
+    expect(computeDiff('', 'caption')).toEqual([
+      { type: 'added', content: 'caption' },
+    ]);
+  });
+});
+
+describe('countEdits', () => {
+  it('returns zero for identical content and normalized line endings', () => {
+    expect(countEdits('same', 'same')).toBe(0);
+    expect(countEdits('first\r\nsecond', 'first\nsecond')).toBe(0);
+    expect(countEdits('', '')).toBe(0);
+  });
+
+  it('counts a replaced line as one edit', () => {
+    expect(countEdits('first\nold\nlast', 'first\nnew\nlast')).toBe(1);
+  });
+
+  it('counts every unpaired addition or removal', () => {
+    expect(countEdits('first', 'first\na\nb\nc')).toBe(3);
+    expect(countEdits('first\na\nb\nc', 'first')).toBe(3);
+  });
+
+  it('pairs replacements and counts remaining additions', () => {
+    expect(countEdits('old', 'new\nextra')).toBe(2);
+  });
+
+  it('counts whitespace-only changes', () => {
+    expect(countEdits('caption', 'caption ')).toBe(1);
+    expect(countEdits('first\n\nthird', 'first\nthird')).toBe(1);
+  });
+});
+
+describe('calculateSimilarity', () => {
+  it('tokenizes all whitespace rather than literal backslash sequences', () => {
+    expect(calculateSimilarity('one\ntwo', 'one two')).toBe(1);
+  });
+});
+
+describe('historical recalculation parity', () => {
+  it.each([
+    ['same', 'same'],
+    ['first\r\nsecond', 'first\nsecond'],
+    ['first', 'first\na\nb\nc'],
+    ['first\nold\nlast', 'first\nnew\nlast'],
+    ['first\n\nthird', 'first\nthird'],
+  ])('matches live edit counting for %j -> %j', (oldText, newText) => {
+    expect(countHistoricalEdits(oldText, newText)).toBe(countEdits(oldText, newText));
+  });
+});

--- a/lib/migrations/2026-07-11-canonical-post-linkage.sql
+++ b/lib/migrations/2026-07-11-canonical-post-linkage.sql
@@ -1,0 +1,11 @@
+-- Workstream 2: canonical post identity and cross-flow linkage.
+-- Additive/idempotent only. No posts.id or posts.post_id values are rewritten.
+
+ALTER TABLE match_suggestions
+  ADD COLUMN IF NOT EXISTS instagram_published_at TIMESTAMP WITH TIME ZONE;
+
+ALTER TABLE scheduled_posts
+  ADD COLUMN IF NOT EXISTS source_post_id BIGINT REFERENCES posts(id);
+
+CREATE INDEX IF NOT EXISTS scheduled_posts_source_post_id_idx
+  ON scheduled_posts(source_post_id);

--- a/lib/migrations/20260711_add_posts_origin.sql
+++ b/lib/migrations/20260711_add_posts_origin.sql
@@ -1,0 +1,30 @@
+-- Classify post rows before voice/training analysis.
+-- Safe to run repeatedly. Existing importer rows have a stable `ig_` post_id.
+
+ALTER TABLE posts ADD COLUMN IF NOT EXISTS origin TEXT;
+
+UPDATE posts
+SET origin = CASE
+  WHEN left(post_id, 3) = 'ig_' THEN 'instagram_import'
+  ELSE 'training_pair'
+END
+WHERE origin IS NULL;
+
+ALTER TABLE posts ALTER COLUMN origin SET DEFAULT 'training_pair';
+ALTER TABLE posts ALTER COLUMN origin SET NOT NULL;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'posts_origin_check'
+      AND conrelid = 'posts'::regclass
+  ) THEN
+    ALTER TABLE posts
+      ADD CONSTRAINT posts_origin_check
+      CHECK (origin IN ('training_pair', 'instagram_import'));
+  END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS posts_origin_idx ON posts(origin);

--- a/lib/post-identity.js
+++ b/lib/post-identity.js
@@ -1,0 +1,36 @@
+const CANONICAL_ID_PATTERN = /^\d+$/;
+
+export function isCanonicalPostId(value) {
+  return CANONICAL_ID_PATTERN.test(String(value ?? '').trim());
+}
+
+/**
+ * Resolve an API/UI post identifier to the canonical posts.id.
+ *
+ * Canonical numeric IDs win. Legacy posts.post_id remains accepted so saved
+ * links and older clients keep working during the identity transition.
+ */
+export async function resolvePostIdentity(supabase, identifier) {
+  const value = String(identifier ?? '').trim();
+  if (!value) return null;
+
+  if (isCanonicalPostId(value)) {
+    const { data, error } = await supabase
+      .from('posts')
+      .select('id, post_id')
+      .eq('id', value)
+      .maybeSingle();
+
+    if (error) throw new Error(error.message);
+    if (data) return data;
+  }
+
+  const { data, error } = await supabase
+    .from('posts')
+    .select('id, post_id')
+    .eq('post_id', value)
+    .maybeSingle();
+
+  if (error) throw new Error(error.message);
+  return data || null;
+}

--- a/lib/post-origin.js
+++ b/lib/post-origin.js
@@ -1,0 +1,14 @@
+export const POST_ORIGINS = Object.freeze({
+  TRAINING_PAIR: 'training_pair',
+  INSTAGRAM_IMPORT: 'instagram_import',
+});
+
+export function isTrainingPair(post) {
+  if (post.origin) {
+    return post.origin === POST_ORIGINS.TRAINING_PAIR;
+  }
+
+  // Before the origin migration, importer-created rows used this stable ID
+  // prefix. Logged rows may still have Instagram IDs after being linked.
+  return !String(post.post_id || '').startsWith('ig_');
+}

--- a/lib/post-origin.test.js
+++ b/lib/post-origin.test.js
@@ -1,0 +1,23 @@
+import { isTrainingPair, POST_ORIGINS } from './post-origin';
+
+describe('isTrainingPair', () => {
+  it('uses explicit origin when present', () => {
+    expect(isTrainingPair({ origin: POST_ORIGINS.TRAINING_PAIR, post_id: 'ig_1' })).toBe(true);
+    expect(isTrainingPair({ origin: POST_ORIGINS.INSTAGRAM_IMPORT, post_id: 'logged_1' })).toBe(false);
+  });
+
+  it('keeps legacy logged rows as training pairs', () => {
+    expect(isTrainingPair({ origin: null, post_id: '1720000000000' })).toBe(true);
+  });
+
+  it('excludes legacy importer rows by their stable post ID prefix', () => {
+    expect(isTrainingPair({ post_id: 'ig_12345' })).toBe(false);
+  });
+
+  it('does not reject linked legacy training rows', () => {
+    expect(isTrainingPair({
+      post_id: '1720000000000',
+      instagram_media_id: '12345',
+    })).toBe(true);
+  });
+});

--- a/lib/publish-state.js
+++ b/lib/publish-state.js
@@ -1,0 +1,36 @@
+export const PUBLISH_NOW_CLAIMABLE_STATUSES = ['draft', 'scheduled', 'failed'];
+export const CRON_CLAIMABLE_STATUSES = ['scheduled'];
+export const HARD_DELETABLE_STATUSES = ['draft', 'failed'];
+export const CANCELLABLE_STATUSES = ['scheduled'];
+
+export function canHardDelete(status) {
+  return HARD_DELETABLE_STATUSES.includes(status);
+}
+
+export function canCancel(status) {
+  return CANCELLABLE_STATUSES.includes(status);
+}
+
+/**
+ * Atomically move one post into publishing. The database RPC performs the
+ * status predicate and update in one statement, so concurrent callers cannot
+ * both claim the same post.
+ */
+export async function claimPostForPublishing(
+  supabase,
+  id,
+  allowedStatuses,
+  { requireDue = false } = {}
+) {
+  const { data, error } = await supabase.rpc('claim_scheduled_post_for_publishing', {
+    p_post_id: id,
+    p_allowed_statuses: allowedStatuses,
+    p_require_due: requireDue,
+  });
+
+  if (error) {
+    throw new Error(`Could not claim post for publishing: ${error.message}`);
+  }
+
+  return Array.isArray(data) ? data[0] || null : data || null;
+}

--- a/lib/publish-state.test.js
+++ b/lib/publish-state.test.js
@@ -1,0 +1,79 @@
+import {
+  CRON_CLAIMABLE_STATUSES,
+  PUBLISH_NOW_CLAIMABLE_STATUSES,
+  canCancel,
+  canHardDelete,
+  claimPostForPublishing,
+} from './publish-state';
+
+describe('publishing state transitions', () => {
+  const statuses = ['draft', 'scheduled', 'publishing', 'published', 'failed', 'cancelled'];
+
+  test.each(statuses)('hard-delete rule for %s', status => {
+    expect(canHardDelete(status)).toBe(['draft', 'failed'].includes(status));
+  });
+
+  test.each(statuses)('cancel rule for %s', status => {
+    expect(canCancel(status)).toBe(status === 'scheduled');
+  });
+
+  test('publish-now and cron expose explicit claim transitions', () => {
+    expect(PUBLISH_NOW_CLAIMABLE_STATUSES).toEqual(['draft', 'scheduled', 'failed']);
+    expect(CRON_CLAIMABLE_STATUSES).toEqual(['scheduled']);
+  });
+});
+
+describe('atomic publishing claim contract', () => {
+  test('only one concurrent caller receives the claimed post', async () => {
+    let status = 'scheduled';
+    const rpc = jest.fn(async (_name, { p_post_id, p_allowed_statuses }) => {
+      if (!p_allowed_statuses.includes(status)) {
+        return { data: [], error: null };
+      }
+
+      status = 'publishing';
+      return { data: [{ id: p_post_id, status }], error: null };
+    });
+    const supabase = { rpc };
+
+    const claims = await Promise.all([
+      claimPostForPublishing(supabase, 42, CRON_CLAIMABLE_STATUSES),
+      claimPostForPublishing(supabase, 42, CRON_CLAIMABLE_STATUSES),
+    ]);
+
+    expect(claims.filter(Boolean)).toHaveLength(1);
+    expect(claims.filter(Boolean)[0]).toEqual({ id: 42, status: 'publishing' });
+    expect(rpc).toHaveBeenCalledTimes(2);
+  });
+
+  test('cron claim requires post to remain due at atomic update time', async () => {
+    const supabase = { rpc: jest.fn().mockResolvedValue({ data: [], error: null }) };
+
+    await claimPostForPublishing(supabase, 42, CRON_CLAIMABLE_STATUSES, {
+      requireDue: true,
+    });
+
+    expect(supabase.rpc).toHaveBeenCalledWith(
+      'claim_scheduled_post_for_publishing',
+      expect.objectContaining({ p_require_due: true })
+    );
+  });
+
+  test('returns null when another worker already owns claim', async () => {
+    const supabase = { rpc: jest.fn().mockResolvedValue({ data: [], error: null }) };
+
+    await expect(
+      claimPostForPublishing(supabase, 42, PUBLISH_NOW_CLAIMABLE_STATUSES)
+    ).resolves.toBeNull();
+  });
+
+  test('surfaces RPC failure as claim-specific error', async () => {
+    const supabase = {
+      rpc: jest.fn().mockResolvedValue({ data: null, error: { message: 'function missing' } }),
+    };
+
+    await expect(
+      claimPostForPublishing(supabase, 42, CRON_CLAIMABLE_STATUSES)
+    ).rejects.toThrow('Could not claim post for publishing: function missing');
+  });
+});

--- a/lib/publishing.js
+++ b/lib/publishing.js
@@ -17,6 +17,14 @@ import {
   getTokenExpiryDate,
 } from './instagram';
 
+export class PublishStatePersistenceError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = 'PublishStatePersistenceError';
+    this.publishSucceeded = true;
+  }
+}
+
 /**
  * Log a publishing action to the publishing_log table.
  */
@@ -233,7 +241,7 @@ export async function executePublish(accessToken, igUserId, scheduledPost, media
   }
 
   // 6. Update scheduled_posts record
-  await supabase
+  const { data: publishedPost, error: publishUpdateError } = await supabase
     .from('scheduled_posts')
     .update({
       status: 'published',
@@ -243,7 +251,22 @@ export async function executePublish(accessToken, igUserId, scheduledPost, media
       updated_at: new Date().toISOString(),
       publish_error: null,
     })
-    .eq('id', postId);
+    .eq('id', postId)
+    .eq('status', 'publishing')
+    .select('id')
+    .maybeSingle();
+
+  if (publishUpdateError) {
+    throw new PublishStatePersistenceError(
+      `Published on Instagram but failed to save publish state: ${publishUpdateError.message}`
+    );
+  }
+
+  if (!publishedPost) {
+    throw new PublishStatePersistenceError(
+      'Published on Instagram but post claim was lost before state could be saved'
+    );
+  }
 
   // 7. Link to source post if this came from the Edit flow
   if (scheduledPost.source_post_id) {

--- a/lib/publishing.js
+++ b/lib/publishing.js
@@ -219,9 +219,11 @@ export async function executePublish(accessToken, igUserId, scheduledPost, media
 
   // 5. Fetch permalink
   let permalink = null;
+  let publishedAt = new Date().toISOString();
   try {
     const { details, newToken } = await getMediaDetails(currentToken, mediaId);
     permalink = details.permalink;
+    publishedAt = details.timestamp || publishedAt;
     if (newToken) {
       await updateTokenIfRefreshed(newToken);
     }
@@ -237,7 +239,7 @@ export async function executePublish(accessToken, igUserId, scheduledPost, media
       status: 'published',
       ig_media_id: mediaId,
       ig_permalink: permalink,
-      published_at: new Date().toISOString(),
+      published_at: publishedAt,
       updated_at: new Date().toISOString(),
       publish_error: null,
     })
@@ -250,10 +252,10 @@ export async function executePublish(accessToken, igUserId, scheduledPost, media
       .update({
         instagram_media_id: mediaId,
         instagram_permalink: permalink,
-        published_at: new Date().toISOString(),
+        published_at: publishedAt,
       })
       .eq('id', scheduledPost.source_post_id);
   }
 
-  return { success: true, mediaId, permalink, dryRun: false, containerId };
+  return { success: true, mediaId, permalink, publishedAt, dryRun: false, containerId };
 }

--- a/lib/supabase-migration-publishing-state-safety.sql
+++ b/lib/supabase-migration-publishing-state-safety.sql
@@ -1,0 +1,29 @@
+-- Publishing state safety migration (2026-07-11)
+-- Run once in Supabase before deploying application code that calls the RPC.
+
+CREATE OR REPLACE FUNCTION claim_scheduled_post_for_publishing(
+  p_post_id BIGINT,
+  p_allowed_statuses TEXT[],
+  p_require_due BOOLEAN DEFAULT FALSE
+)
+RETURNS SETOF scheduled_posts
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  UPDATE scheduled_posts
+  SET status = 'publishing', updated_at = now()
+  WHERE id = p_post_id
+    AND status = ANY(p_allowed_statuses)
+    AND (NOT p_require_due OR scheduled_at <= now())
+  RETURNING *;
+$$;
+
+REVOKE ALL ON FUNCTION claim_scheduled_post_for_publishing(BIGINT, TEXT[], BOOLEAN) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION claim_scheduled_post_for_publishing(BIGINT, TEXT[], BOOLEAN) TO service_role;
+
+ALTER TABLE publishing_log
+  DROP CONSTRAINT IF EXISTS publishing_log_scheduled_post_id_fkey;
+ALTER TABLE publishing_log
+  ADD CONSTRAINT publishing_log_scheduled_post_id_fkey
+  FOREIGN KEY (scheduled_post_id) REFERENCES scheduled_posts(id) ON DELETE SET NULL;

--- a/lib/supabase-schema-publishing.sql
+++ b/lib/supabase-schema-publishing.sql
@@ -34,6 +34,7 @@ CREATE TABLE scheduled_posts (
 CREATE INDEX scheduled_posts_status_idx ON scheduled_posts(status);
 CREATE INDEX scheduled_posts_scheduled_at_idx ON scheduled_posts(scheduled_at);
 CREATE INDEX scheduled_posts_ig_media_id_idx ON scheduled_posts(ig_media_id);
+CREATE INDEX scheduled_posts_source_post_id_idx ON scheduled_posts(source_post_id);
 
 ALTER TABLE scheduled_posts ENABLE ROW LEVEL SECURITY;
 
@@ -100,3 +101,5 @@ CREATE POLICY "Deny anon access caption_templates" ON caption_templates FOR ALL 
 -- CREATE TABLE IF NOT EXISTS media_uploads ( ... );
 -- CREATE TABLE IF NOT EXISTS publishing_log ( ... );
 -- CREATE TABLE IF NOT EXISTS caption_templates ( ... );
+-- ALTER TABLE scheduled_posts ADD COLUMN IF NOT EXISTS source_post_id BIGINT REFERENCES posts(id);
+-- CREATE INDEX IF NOT EXISTS scheduled_posts_source_post_id_idx ON scheduled_posts(source_post_id);

--- a/lib/supabase-schema-publishing.sql
+++ b/lib/supabase-schema-publishing.sql
@@ -66,7 +66,7 @@ CREATE POLICY "Deny anon access media_uploads" ON media_uploads FOR ALL USING (f
 -- Audit trail for publish attempts (debugging + history UI)
 CREATE TABLE publishing_log (
   id BIGINT PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
-  scheduled_post_id BIGINT REFERENCES scheduled_posts(id) ON DELETE CASCADE,
+  scheduled_post_id BIGINT REFERENCES scheduled_posts(id) ON DELETE SET NULL,
   action TEXT NOT NULL,                      -- container_created, status_check, published, failed, retry
   details JSONB,                             -- API responses, error details
   created_at TIMESTAMP WITH TIME ZONE DEFAULT now()
@@ -103,3 +103,33 @@ CREATE POLICY "Deny anon access caption_templates" ON caption_templates FOR ALL 
 -- CREATE TABLE IF NOT EXISTS caption_templates ( ... );
 -- ALTER TABLE scheduled_posts ADD COLUMN IF NOT EXISTS source_post_id BIGINT REFERENCES posts(id);
 -- CREATE INDEX IF NOT EXISTS scheduled_posts_source_post_id_idx ON scheduled_posts(source_post_id);
+
+-- Atomic idempotency guard used by publish-now and cron. One concurrent caller
+-- can change a claimable row to publishing; all others receive zero rows.
+CREATE OR REPLACE FUNCTION claim_scheduled_post_for_publishing(
+  p_post_id BIGINT,
+  p_allowed_statuses TEXT[],
+  p_require_due BOOLEAN DEFAULT FALSE
+)
+RETURNS SETOF scheduled_posts
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  UPDATE scheduled_posts
+  SET status = 'publishing', updated_at = now()
+  WHERE id = p_post_id
+    AND status = ANY(p_allowed_statuses)
+    AND (NOT p_require_due OR scheduled_at <= now())
+  RETURNING *;
+$$;
+
+REVOKE ALL ON FUNCTION claim_scheduled_post_for_publishing(BIGINT, TEXT[], BOOLEAN) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION claim_scheduled_post_for_publishing(BIGINT, TEXT[], BOOLEAN) TO service_role;
+
+-- Existing databases: preserve audit rows when a deletable draft/failed row is removed.
+ALTER TABLE publishing_log
+  DROP CONSTRAINT IF EXISTS publishing_log_scheduled_post_id_fkey;
+ALTER TABLE publishing_log
+  ADD CONSTRAINT publishing_log_scheduled_post_id_fkey
+  FOREIGN KEY (scheduled_post_id) REFERENCES scheduled_posts(id) ON DELETE SET NULL;

--- a/lib/supabase-schema.sql
+++ b/lib/supabase-schema.sql
@@ -227,6 +227,7 @@ CREATE TABLE match_suggestions (
   instagram_media_id TEXT NOT NULL,
   instagram_permalink TEXT,
   instagram_caption TEXT,
+  instagram_published_at TIMESTAMP WITH TIME ZONE,
   media_type TEXT,
   confidence_score DECIMAL(4,3) NOT NULL,
   status TEXT NOT NULL DEFAULT 'pending',
@@ -269,6 +270,7 @@ CREATE POLICY "Deny anon access match_suggestions" ON match_suggestions FOR ALL 
 -- Migration: add media_type to match_suggestions
 -- =====================================================
 -- ALTER TABLE match_suggestions ADD COLUMN IF NOT EXISTS media_type TEXT;
+-- ALTER TABLE match_suggestions ADD COLUMN IF NOT EXISTS instagram_published_at TIMESTAMP WITH TIME ZONE;
 
 -- =====================================================
 -- Niche hashtag library (manual input)

--- a/lib/supabase-schema.sql
+++ b/lib/supabase-schema.sql
@@ -10,6 +10,8 @@ CREATE TABLE posts (
   ai_version TEXT NOT NULL,
   final_version TEXT NOT NULL,
   edit_count INT NOT NULL DEFAULT 0,
+  origin TEXT NOT NULL DEFAULT 'training_pair'
+    CHECK (origin IN ('training_pair', 'instagram_import')),
   created_at TIMESTAMP WITH TIME ZONE DEFAULT now(),
   updated_at TIMESTAMP WITH TIME ZONE DEFAULT now(),
   -- Instagram integration fields
@@ -26,6 +28,9 @@ CREATE INDEX posts_post_id_idx ON posts(post_id);
 
 -- Create index on instagram_media_id for metrics lookups
 CREATE INDEX posts_instagram_media_id_idx ON posts(instagram_media_id);
+
+-- Create index for filtering training pairs from Instagram imports
+CREATE INDEX posts_origin_idx ON posts(origin);
 
 -- Enable Row Level Security
 ALTER TABLE posts ENABLE ROW LEVEL SECURITY;
@@ -122,6 +127,7 @@ CREATE POLICY "Deny anon access post_metrics" ON post_metrics FOR ALL USING (fal
 -- ALTER TABLE posts ADD COLUMN IF NOT EXISTS instagram_media_id TEXT;
 -- ALTER TABLE posts ADD COLUMN IF NOT EXISTS instagram_permalink TEXT;
 -- ALTER TABLE posts ADD COLUMN IF NOT EXISTS published_at TIMESTAMP WITH TIME ZONE;
+-- See lib/migrations/20260711_add_posts_origin.sql for safe origin backfill.
 -- CREATE INDEX IF NOT EXISTS posts_instagram_media_id_idx ON posts(instagram_media_id);
 
 -- =====================================================

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build": "next build",
     "start": "next start",
     "test": "jest",
-    "test:watch": "jest --watch"
+    "test:watch": "jest --watch",
+    "recalculate:edit-counts": "node scripts/recalculate-edit-counts.cjs"
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.44.0",

--- a/scripts/recalculate-edit-counts.cjs
+++ b/scripts/recalculate-edit-counts.cjs
@@ -1,0 +1,124 @@
+#!/usr/bin/env node
+
+const { createClient } = require('@supabase/supabase-js');
+
+const APPLY_CONFIRMATION = 'RECALCULATE_EDIT_COUNTS';
+
+function splitLines(text) {
+  const normalized = String(text ?? '').replace(/\r\n?/g, '\n');
+  return normalized === '' ? [] : normalized.split('\n');
+}
+
+// Mirrors lib/diff.js. Kept dependency-free so this operational script works
+// under the repository's CommonJS package configuration.
+function countEdits(oldText, newText) {
+  const oldLines = splitLines(oldText);
+  const newLines = splitLines(newText);
+  const lcs = Array.from(
+    { length: oldLines.length + 1 },
+    () => new Array(newLines.length + 1).fill(0)
+  );
+
+  for (let oldIndex = oldLines.length - 1; oldIndex >= 0; oldIndex--) {
+    for (let newIndex = newLines.length - 1; newIndex >= 0; newIndex--) {
+      lcs[oldIndex][newIndex] = oldLines[oldIndex] === newLines[newIndex]
+        ? lcs[oldIndex + 1][newIndex + 1] + 1
+        : Math.max(lcs[oldIndex + 1][newIndex], lcs[oldIndex][newIndex + 1]);
+    }
+  }
+
+  let oldIndex = 0;
+  let newIndex = 0;
+  let additions = 0;
+  let removals = 0;
+
+  while (oldIndex < oldLines.length && newIndex < newLines.length) {
+    if (oldLines[oldIndex] === newLines[newIndex]) {
+      oldIndex++;
+      newIndex++;
+    } else if (lcs[oldIndex + 1][newIndex] >= lcs[oldIndex][newIndex + 1]) {
+      removals++;
+      oldIndex++;
+    } else {
+      additions++;
+      newIndex++;
+    }
+  }
+
+  removals += oldLines.length - oldIndex;
+  additions += newLines.length - newIndex;
+  return Math.max(additions, removals);
+}
+
+async function loadTrainingPairs(supabase) {
+  const pageSize = 1000;
+  const rows = [];
+
+  for (let from = 0; ; from += pageSize) {
+    const { data, error } = await supabase
+      .from('posts')
+      .select('id,post_id,ai_version,final_version,edit_count,origin')
+      .eq('origin', 'training_pair')
+      .order('id', { ascending: true })
+      .range(from, from + pageSize - 1);
+
+    if (error) throw error;
+    rows.push(...data);
+    if (data.length < pageSize) return rows;
+  }
+}
+
+async function main() {
+  const apply = process.argv.includes('--apply');
+  const confirmation = process.argv.find(arg => arg.startsWith('--confirm='))?.split('=')[1];
+  if (apply && confirmation !== APPLY_CONFIRMATION) {
+    throw new Error(`Refusing writes. Add --confirm=${APPLY_CONFIRMATION} with --apply.`);
+  }
+
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !serviceRoleKey) {
+    throw new Error('NEXT_PUBLIC_SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY are required.');
+  }
+
+  const supabase = createClient(url, serviceRoleKey, {
+    auth: { autoRefreshToken: false, persistSession: false },
+  });
+  const rows = await loadTrainingPairs(supabase);
+  const changes = rows
+    .map(row => ({ ...row, recalculated: countEdits(row.ai_version, row.final_version) }))
+    .filter(row => row.recalculated !== row.edit_count);
+
+  console.log(`${apply ? 'APPLY' : 'DRY RUN'}: ${rows.length} training pairs checked; ${changes.length} changes.`);
+  console.table(changes.slice(0, 50).map(row => ({
+    id: row.id,
+    post_id: row.post_id,
+    current: row.edit_count,
+    recalculated: row.recalculated,
+  })));
+
+  if (!apply) {
+    console.log(`No rows changed. Re-run with --apply --confirm=${APPLY_CONFIRMATION} after reviewing output.`);
+    return;
+  }
+
+  for (const row of changes) {
+    const { error } = await supabase
+      .from('posts')
+      .update({ edit_count: row.recalculated })
+      .eq('id', row.id)
+      .eq('origin', 'training_pair');
+    if (error) throw error;
+  }
+
+  console.log(`${changes.length} training-pair rows updated.`);
+}
+
+if (require.main === module) {
+  main().catch(error => {
+    console.error(error.message || error);
+    process.exit(1);
+  });
+}
+
+module.exports = { countEdits };


### PR DESCRIPTION
## Summary
- protect training-pair integrity and classify imported posts
- canonicalize post identity across compose, history, logging, and publishing
- harden publishing state transitions and duplicate-publish prevention
- improve OAuth feedback and application UX shell
- add DevOps MI integration record with conflict-resolution audit

## Validation
- `npm ci`
- `npm test -- --runInBand` — 15 suites, 59 tests passed
- `npm run build` — production build passed
- `git diff --check`

## Migrations required
- `lib/migrations/20260711_add_posts_origin.sql`
- `lib/migrations/2026-07-11-canonical-post-linkage.sql`
- `lib/supabase-migration-publishing-state-safety.sql`